### PR TITLE
Adds support for importing wallets using private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There is a global [`before()`](https://github.com/synthetixio/synpress/blob/mast
 - changes network (defaults to `kovan`) or creates custom network and changes to it (depending on your setup)
 - switches back to Cypress window and starts testing
 
-It requires environmental variable called `SECRET_WORDS` to be present in following format => `'word1, word2, etc..'`.
+It requires environmental variable called `SECRET_WORDS` to be present in following format => `'word1, word2, etc..'` or a signer's private key in an environmental variable called `PRIVATE_KEY`.
 
 To change default network (`kovan`), you can use `NETWORK_NAME` environmental variable, for example: `NETWORK_NAME=rinkeby`.
 
@@ -109,9 +109,9 @@ Metamask version is hardcoded and frequently updated under supervision to avoid 
 
 If you don't want to use environmental variables, you can modify [`setupMetamask()`](https://github.com/synthetixio/synpress/blob/master/support/index.js#L26) to following:
 
-`setupMetamask(secretWords, network, password)`, for example: `setupMetamask('word1, word2, etc..', 'mainnet', 'password')`.
+`setupMetamask(secret, network, password)`, for example: `setupMetamask('word1, word2, etc..', 'mainnet', 'password')`.
 
-You can also add and switch to custom network by passing an `object` instead of `string` inside `setupMetamask(secretWords, network, password)` function for `network` parameter.
+You can also add and switch to custom network by passing an `object` instead of `string` inside `setupMetamask(secret, network, password)` function for `network` parameter.
 
 If you want to use Etherscan API helpers, you will have to provide Etherscan API key using `ETHERSCAN_KEY` enironmental variable.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There is a global [`before()`](https://github.com/synthetixio/synpress/blob/mast
 - changes network (defaults to `kovan`) or creates custom network and changes to it (depending on your setup)
 - switches back to Cypress window and starts testing
 
-It requires environmental variable called `SECRET_WORDS` to be present in following format => `'word1, word2, etc..'` or a signer's private key in an environmental variable called `PRIVATE_KEY`.
+It requires environmental variable called `SECRET_WORDS` to be present in following format => `'word1, word2, etc..'` or private key in an environmental variable called `PRIVATE_KEY`.
 
 To change default network (`kovan`), you can use `NETWORK_NAME` environmental variable, for example: `NETWORK_NAME=rinkeby`.
 
@@ -109,9 +109,9 @@ Metamask version is hardcoded and frequently updated under supervision to avoid 
 
 If you don't want to use environmental variables, you can modify [`setupMetamask()`](https://github.com/synthetixio/synpress/blob/master/support/index.js#L26) to following:
 
-`setupMetamask(secret, network, password)`, for example: `setupMetamask('word1, word2, etc..', 'mainnet', 'password')`.
+`setupMetamask(secretWordsOrPrivateKey, network, password)`, for example: `setupMetamask('word1, word2, etc..', 'mainnet', 'password')`.
 
-You can also add and switch to custom network by passing an `object` instead of `string` inside `setupMetamask(secret, network, password)` function for `network` parameter.
+You can also add and switch to custom network by passing an `object` instead of `string` inside `setupMetamask(secretWordsOrPrivateKey, network, password)` function for `network` parameter.
 
 If you want to use Etherscan API helpers, you will have to provide Etherscan API key using `ETHERSCAN_KEY` enironmental variable.
 

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -370,7 +370,7 @@ module.exports = {
     await puppeteer.waitAndClick(mainPageElements.accountModal.closeButton);
     return walletAddress;
   },
-  initialSetup: async ({ secretWords, network, password }) => {
+  initialSetup: async ({ secretWordsOrPrivateKey, network, password }) => {
     const isCustomNetwork =
       process.env.NETWORK_NAME && process.env.RPC_URL && process.env.CHAIN_ID;
 
@@ -382,42 +382,17 @@ module.exports = {
       null
     ) {
       await module.exports.confirmWelcomePage();
-      await module.exports.importWallet(secretWords, password);
+      if (secretWordsOrPrivateKey.includes(' ')) {
+        await module.exports.importWallet(secretWordsOrPrivateKey, password);
+      } else {
+        await module.exports.createWallet(password);
+        await module.exports.importFromPrivateKey(secretWordsOrPrivateKey);
+      }
       if (isCustomNetwork) {
         await module.exports.addNetwork(network);
       } else {
         await module.exports.changeNetwork(network);
       }
-      walletAddress = await module.exports.getWalletAddress();
-      await puppeteer.switchToCypressWindow();
-      return true;
-    } else {
-      await module.exports.unlock(password);
-      walletAddress = await module.exports.getWalletAddress();
-      await puppeteer.switchToCypressWindow();
-      return true;
-    }
-  },
-  initialSetupWithPrivateKey: async ({ privateKey, network, password }) => {
-    const isCustomNetwork =
-      process.env.NETWORK_NAME && process.env.RPC_URL && process.env.CHAIN_ID;
-    await puppeteer.init();
-    await puppeteer.assignWindows();
-    await puppeteer.metamaskWindow().waitForTimeout(1000);
-    if (
-      (await puppeteer.metamaskWindow().$(unlockPageElements.unlockPage)) ===
-      null
-    ) {
-      await module.exports.confirmWelcomePage();
-      await module.exports.createWallet(password);
-      if (isCustomNetwork) {
-        await module.exports.addNetwork(network);
-      } else {
-        await module.exports.changeNetwork(network);
-      }
-
-      await module.exports.importFromPrivateKey(privateKey);
-
       walletAddress = await module.exports.getWalletAddress();
       await puppeteer.switchToCypressWindow();
       return true;

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -6,6 +6,8 @@ const {
   firstTimeFlowPageElements,
   metametricsPageElements,
   firstTimeFlowFormPageElements,
+  secureYourWalletPageElements,
+  revealSeedPageElements,
   endOfFlowPageElements,
 } = require('../pages/metamask/first-time-flow-page');
 const { mainPageElements } = require('../pages/metamask/main-page');
@@ -103,10 +105,8 @@ module.exports = {
     await puppeteer.waitAndClick(firstTimeFlowFormPageElements.importButton);
 
     await puppeteer.waitFor(pageElements.loadingSpinner);
-    await puppeteer.waitAndClick(firstTimeFlowFormPageElements.nextButton);
-    await puppeteer.waitAndClick(
-      firstTimeFlowFormPageElements.remindMeLaterButton,
-    );
+    await puppeteer.waitAndClick(secureYourWalletPageElements.nextButton);
+    await puppeteer.waitAndClick(revealSeedPageElements.remindLaterButton);
     await puppeteer.waitFor(mainPageElements.walletOverview);
 
     // close popup if present
@@ -125,10 +125,11 @@ module.exports = {
     );
 
     await puppeteer.waitAndType(
-      mainPageElements.newAccountImport.input,
+      mainPageElements.importAccount.input,
       privateKey,
     );
-    await puppeteer.waitAndClick(mainPageElements.newAccountImport.button);
+    await puppeteer.waitAndClick(mainPageElements.importAccount.importButton);
+    return true;
   },
   changeNetwork: async network => {
     setNetwork(network);

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -86,7 +86,7 @@ module.exports = {
     }
     return true;
   },
-  createWallet: async (password) => {
+  createWallet: async password => {
     await puppeteer.waitAndClick(firstTimeFlowPageElements.createWalletButton);
     await puppeteer.waitAndClick(metametricsPageElements.optOutAnalyticsButton);
     await puppeteer.waitAndType(
@@ -97,12 +97,16 @@ module.exports = {
       firstTimeFlowFormPageElements.confirmPasswordInput,
       password,
     );
-    await puppeteer.waitAndClick(firstTimeFlowFormPageElements.newSignupCheckbox);
+    await puppeteer.waitAndClick(
+      firstTimeFlowFormPageElements.newSignupCheckbox,
+    );
     await puppeteer.waitAndClick(firstTimeFlowFormPageElements.importButton);
 
     await puppeteer.waitFor(pageElements.loadingSpinner);
     await puppeteer.waitAndClick(firstTimeFlowFormPageElements.nextButton);
-    await puppeteer.waitAndClick(firstTimeFlowFormPageElements.remindMeLaterButton);
+    await puppeteer.waitAndClick(
+      firstTimeFlowFormPageElements.remindMeLaterButton,
+    );
     await puppeteer.waitFor(mainPageElements.walletOverview);
 
     // close popup if present
@@ -114,11 +118,16 @@ module.exports = {
     }
     return true;
   },
-  importFromPrivateKey: async (privateKey) => {
+  importFromPrivateKey: async privateKey => {
     await puppeteer.waitAndClick(mainPageElements.accountMenu.button);
-    await puppeteer.waitAndClick(mainPageElements.accountMenu.importAccountButton);
+    await puppeteer.waitAndClick(
+      mainPageElements.accountMenu.importAccountButton,
+    );
 
-    await puppeteer.waitAndType(mainPageElements.newAccountImport.input, privateKey);
+    await puppeteer.waitAndType(
+      mainPageElements.newAccountImport.input,
+      privateKey,
+    );
     await puppeteer.waitAndClick(mainPageElements.newAccountImport.button);
   },
   changeNetwork: async network => {

--- a/pages/metamask/first-time-flow-page.js
+++ b/pages/metamask/first-time-flow-page.js
@@ -7,11 +7,14 @@ module.exports.welcomePageElements = {
   confirmButton,
 };
 
+
 const firstTimeFlowPage = '.first-time-flow';
 const importWalletButton = `${firstTimeFlowPage} .first-time-flow__button`;
+const createWalletButton = `${firstTimeFlowPage} .select-action__select-button:nth-child(2) .first-time-flow__button`;
 module.exports.firstTimeFlowPageElements = {
   firstTimeFlowPage,
   importWalletButton,
+  createWalletButton
 };
 
 const metametricsPage = '.metametrics-opt-in';
@@ -27,6 +30,11 @@ const passwordInput = `${firstTimeFlowFormPage} #password`;
 const confirmPasswordInput = `${firstTimeFlowFormPage} #confirm-password`;
 const termsCheckbox = `${firstTimeFlowFormPage} .first-time-flow__terms`;
 const importButton = `${firstTimeFlowFormPage} .first-time-flow__button`;
+const newPasswordInput = `${firstTimeFlowFormPage} #create-password`;
+const newSignupCheckbox = `${firstTimeFlowFormPage} .first-time-flow__checkbox`;
+const nextButton = `.seed-phrase-intro button.button.btn-primary`;
+const remindMeLaterButton = `.button.btn-secondary.first-time-flow__button`;
+
 module.exports.firstTimeFlowFormPageElements = {
   firstTimeFlowFormPage,
   secretWordsInput,
@@ -34,6 +42,10 @@ module.exports.firstTimeFlowFormPageElements = {
   confirmPasswordInput,
   termsCheckbox,
   importButton,
+  newPasswordInput,
+  newSignupCheckbox,
+  nextButton,
+  remindMeLaterButton
 };
 
 const endOfFlowPage = '.end-of-flow';

--- a/pages/metamask/first-time-flow-page.js
+++ b/pages/metamask/first-time-flow-page.js
@@ -7,14 +7,13 @@ module.exports.welcomePageElements = {
   confirmButton,
 };
 
-
 const firstTimeFlowPage = '.first-time-flow';
-const importWalletButton = `${firstTimeFlowPage} .first-time-flow__button`;
+const importWalletButton = `${firstTimeFlowPage} .select-action__select-button:nth-child(1) .first-time-flow__button`;
 const createWalletButton = `${firstTimeFlowPage} .select-action__select-button:nth-child(2) .first-time-flow__button`;
 module.exports.firstTimeFlowPageElements = {
   firstTimeFlowPage,
   importWalletButton,
-  createWalletButton
+  createWalletButton,
 };
 
 const metametricsPage = '.metametrics-opt-in';
@@ -32,8 +31,6 @@ const termsCheckbox = `${firstTimeFlowFormPage} .first-time-flow__terms`;
 const importButton = `${firstTimeFlowFormPage} .first-time-flow__button`;
 const newPasswordInput = `${firstTimeFlowFormPage} #create-password`;
 const newSignupCheckbox = `${firstTimeFlowFormPage} .first-time-flow__checkbox`;
-const nextButton = `.seed-phrase-intro button.button.btn-primary`;
-const remindMeLaterButton = `.button.btn-secondary.first-time-flow__button`;
 
 module.exports.firstTimeFlowFormPageElements = {
   firstTimeFlowFormPage,
@@ -44,8 +41,13 @@ module.exports.firstTimeFlowFormPageElements = {
   importButton,
   newPasswordInput,
   newSignupCheckbox,
+};
+
+const secureYourWalletPage = '.first-time-flow__wrapper';
+const nextButton = `${secureYourWalletPage} button`;
+module.exports.secureYourWalletPageElements = {
+  secureYourWalletPage,
   nextButton,
-  remindMeLaterButton
 };
 
 const endOfFlowPage = '.end-of-flow';

--- a/pages/metamask/main-page.js
+++ b/pages/metamask/main-page.js
@@ -14,6 +14,7 @@ const popup = {
 const accountMenu = {
   button: '.account-menu__icon',
   settingsButton: '.account-menu__item--clickable:nth-child(11)',
+  importAccountButton: '.account-menu__item--clickable:nth-child(7)',
 };
 
 const optionsMenu = {
@@ -36,6 +37,11 @@ const accountModal = {
   closeButton: '.account-modal__close',
 };
 
+const newAccountImport = {
+  input: "#private-key-box",
+  button: ".btn-secondary.button.new-account-create-form__button"
+}
+
 module.exports.mainPageElements = {
   networkSwitcher,
   walletOverview,
@@ -44,4 +50,5 @@ module.exports.mainPageElements = {
   optionsMenu,
   connectedSites,
   accountModal,
+  newAccountImport
 };

--- a/pages/metamask/main-page.js
+++ b/pages/metamask/main-page.js
@@ -37,10 +37,13 @@ const accountModal = {
   closeButton: '.account-modal__close',
 };
 
-const newAccountImport = {
-  input: "#private-key-box",
-  button: ".btn-secondary.button.new-account-create-form__button"
-}
+const importAccountSelector = '.new-account';
+const importAccount = {
+  page: importAccountSelector,
+  input: `${importAccountSelector} #private-key-box`,
+  cancelButton: `${importAccountSelector} .btn-default`,
+  importButton: `${importAccountSelector} .btn-secondary`,
+};
 
 module.exports.mainPageElements = {
   networkSwitcher,
@@ -50,5 +53,5 @@ module.exports.mainPageElements = {
   optionsMenu,
   connectedSites,
   accountModal,
-  newAccountImport
+  importAccount,
 };

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -150,21 +150,25 @@ module.exports = (on, config) => {
     fetchMetamaskWalletAddress: async () => {
       return metamask.walletAddress();
     },
-    setupMetamask: async ({ secret, network = 'kovan', password }) => {
+    setupMetamask: async ({
+      secretWordsOrPrivateKey,
+      network = 'kovan',
+      password,
+    }) => {
       if (process.env.NETWORK_NAME) {
         network = process.env.NETWORK_NAME;
       }
       if (process.env.PRIVATE_KEY) {
-        secret = process.env.PRIVATE_KEY;
+        secretWordsOrPrivateKey = process.env.PRIVATE_KEY;
       }
       if (process.env.SECRET_WORDS) {
-        secret = process.env.SECRET_WORDS;
+        secretWordsOrPrivateKey = process.env.SECRET_WORDS;
       }
-      if (secret && secret.startsWith("0x")) {
-        await metamask.initialSetupWithPrivateKey({ privateKey: secret, network, password });
-      } else {
-        await metamask.initialSetup({ secret, network, password });
-      }
+      await metamask.initialSetup({
+        secretWordsOrPrivateKey,
+        network,
+        password,
+      });
       return true;
     },
     snxExchangerSettle: async ({ asset, walletAddress, privateKey }) => {

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -150,14 +150,21 @@ module.exports = (on, config) => {
     fetchMetamaskWalletAddress: async () => {
       return metamask.walletAddress();
     },
-    setupMetamask: async ({ secretWords, network = 'kovan', password }) => {
+    setupMetamask: async ({ secret, network = 'kovan', password }) => {
       if (process.env.NETWORK_NAME) {
         network = process.env.NETWORK_NAME;
       }
-      if (process.env.SECRET_WORDS) {
-        secretWords = process.env.SECRET_WORDS;
+      if (process.env.PRIVATE_KEY) {
+        secret = process.env.PRIVATE_KEY;
       }
-      await metamask.initialSetup({ secretWords, network, password });
+      if (process.env.SECRET_WORDS) {
+        secret = process.env.SECRET_WORDS;
+      }
+      if (secret && secret.startsWith("0x")) {
+        await metamask.initialSetupWithPrivateKey({ privateKey: secret, network, password });
+      } else {
+        await metamask.initialSetup({ secret, network, password });
+      }
       return true;
     },
     snxExchangerSettle: async ({ asset, walletAddress, privateKey }) => {


### PR DESCRIPTION
Thanks for building this! I was looking to set up e2e tests locally that would interact with a node provisioned by hardhat, but realized I'd need to pass in a private key, rather than a mnemonic phrase, to connect a wallet. This PR adds support for this. The browser automation looks like [this](https://www.loom.com/share/fead844cb0a548bab94dbb11b30d204e).

If you're interested in merging, happy to make further updates. Let me know.