### PR TITLE
Fix recognition of custom networks

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -386,7 +386,7 @@ module.exports = {
   },
   initialSetup: async ({ secretWordsOrPrivateKey, network, password }) => {
     const isCustomNetwork =
-      process.env.NETWORK_NAME && process.env.RPC_URL && process.env.CHAIN_ID;
+      (process.env.NETWORK_NAME && process.env.RPC_URL && process.env.CHAIN_ID) || typeof(network) == 'object';
 
     await puppeteer.init();
     await puppeteer.assignWindows();


### PR DESCRIPTION
This changes the way custom networks are recognized and allows for specifying custom ones purely via changing before() script (as mentioned in the documentation).