### PR TITLE
fix: add another condition for cypress window filter

### DIFF
--- a/commands/puppeteer.js
+++ b/commands/puppeteer.js
@@ -37,6 +37,8 @@ module.exports = {
     for (const page of pages) {
       if (page.url().includes('integration')) {
         mainWindow = page;
+      } else if (page.url().includes('tests')) {
+        mainWindow = page;
       } else if (page.url().includes('extension')) {
         metamaskWindow = page;
       }


### PR DESCRIPTION
![Screen Shot 2021-10-18 at 5 14 02 PM](https://user-images.githubusercontent.com/52531715/137819176-31569767-0323-4b06-bbd8-3112ce308f2f.png)

When running tests by `synpress open`, the url doesn't contain integration. As a result, it fails to get `mainWindow` (the  cypress window) and the error occurs.

I suggest adding another filter `tests` for this.