### PR TITLE
Fix getting stuck when importing private key

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -109,6 +109,7 @@ module.exports = {
     await puppeteer.waitAndClick(firstTimeFlowFormPageElements.importButton);
 
     await puppeteer.waitFor(pageElements.loadingSpinner);
+    await puppeteer.waitFor(secureYourWalletPageElements.secureYourWalletPage);
     await puppeteer.waitAndClick(secureYourWalletPageElements.nextButton);
     await puppeteer.waitAndClick(revealSeedPageElements.remindLaterButton);
     await puppeteer.waitFor(mainPageElements.walletOverview);


### PR DESCRIPTION
I'm not sure why but when I try to import private key, it gets stuck and won't click the "Next" button in `secureYourWalletPage`, adding a line to wait for `secureYourWalletPage` loading would fix this.