### PR TITLE
Fix confirm transaction may not work

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -406,6 +406,7 @@ module.exports = {
     }
     // metamask reloads popup after changing a fee, you have to wait for this event otherwise transaction will fail
     await puppeteer.metamaskWindow().waitForTimeout(3000);
+    await notificationPage.waitForFunction(`document.querySelector('${confirmPageElements.gasLimitInput}').value != "0"`);
     await puppeteer.waitAndClick(
       confirmPageElements.confirmButton,
       notificationPage,


### PR DESCRIPTION
It's very possible that the gas limit doesn't update in 3 seconds, and then the transaction fails.
Checking the field of gas limit would prevent this from happening. 