### PR TITLE
Add configs for gas fee and gas limit

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -440,7 +440,7 @@ module.exports = {
     await puppeteer.metamaskWindow().waitForTimeout(3000);
     return true;
   },
-  confirmTransaction: async () => {
+  confirmTransaction: async gasConfig => {
     const isKovanTestnet = getNetwork().networkName === 'kovan';
     // todo: remove waitForTimeout below after improving switchToMetamaskNotification
     await puppeteer.metamaskWindow().waitForTimeout(1000);
@@ -451,11 +451,25 @@ module.exports = {
         confirmPageElements.gasFeeInput,
         notificationPage,
       );
+    } else if (gasConfig && gasConfig.gasFee) {
+      await puppeteer.waitAndSetValue(
+        gasConfig.gasFee.toString(),
+        confirmPageElements.gasFeeInput,
+        notificationPage,
+      );
     } else {
       await puppeteer.waitAndClick(
         confirmPageElements.gasFeeArrowUpButton,
         notificationPage,
         10,
+      );
+    }
+
+    if (gasConfig && gasConfig.gasLimit) {
+      await puppeteer.waitAndSetValue(
+        gasConfig.gasLimit.toString(),
+        confirmPageElements.gasLimitInput,
+        notificationPage,
       );
     }
     // metamask reloads popup after changing a fee, you have to wait for this event otherwise transaction will fail

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -159,8 +159,8 @@ module.exports = (on, config) => {
       const accepted = await metamask.acceptAccess();
       return accepted;
     },
-    confirmMetamaskTransaction: async () => {
-      const confirmed = await metamask.confirmTransaction();
+    confirmMetamaskTransaction: async gasConfig => {
+      const confirmed = await metamask.confirmTransaction(gasConfig);
       return confirmed;
     },
     rejectMetamaskTransaction: async () => {

--- a/support/commands.js
+++ b/support/commands.js
@@ -99,8 +99,8 @@ Cypress.Commands.add('acceptMetamaskAccess', () => {
   return cy.task('acceptMetamaskAccess');
 });
 
-Cypress.Commands.add('confirmMetamaskTransaction', () => {
-  return cy.task('confirmMetamaskTransaction');
+Cypress.Commands.add('confirmMetamaskTransaction', gasConfig => {
+  return cy.task('confirmMetamaskTransaction', gasConfig);
 });
 
 Cypress.Commands.add('rejectMetamaskTransaction', () => {

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -154,8 +154,9 @@ declare namespace Cypress {
      * Confirm metamask atransaction
      * @example
      * cy.confirmMetamaskTransaction()
+     * cy.confirmMetamaskTransaction({gasFee: 10, gasLimit: 1000000})
      */
-    confirmMetamaskTransaction(): Chainable<Subject>;
+    confirmMetamaskTransaction(gasConfig : object | undefined): Chainable<Subject>;
     /**
      * Reject metamask transaction
      * @example


### PR DESCRIPTION
Sometimes the `cy.confirmMetamaskTransaction` timeouts for my tests. After some investigation, I found that it's because the MetaMask can't get the gas limit or take too much time to get it. So I added a `gasConfig` parameter to `confirmMetamaskTransaction()` and I don't need to wait for the gas limit response from MetaMask anymore. :)