### PR TITLE
fix unlock close popup

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -55,10 +55,21 @@ module.exports = {
     await puppeteer.waitAndClick(welcomePageElements.confirmButton);
     return true;
   },
+  closeMetamaskPopup: async () => {
+    if (
+      (await puppeteer.metamaskWindow().$(mainPageElements.popup.container)) !==
+      null
+    ) {
+      await puppeteer.waitAndClick(mainPageElements.popup.closeButton);
+    }
+    return true
+  },
   unlock: async password => {
     await module.exports.fixBlankPage();
     await puppeteer.waitAndType(unlockPageElements.passwordInput, password);
     await puppeteer.waitAndClick(unlockPageElements.unlockButton);
+    await puppeteer.waitFor(mainPageElements.walletOverview);
+    await module.exports.closePopup();
     return true;
   },
   importWallet: async (secretWords, password) => {
@@ -80,14 +91,7 @@ module.exports = {
     await puppeteer.waitAndClick(firstTimeFlowFormPageElements.importButton);
     await puppeteer.waitAndClick(endOfFlowPageElements.allDoneButton);
     await puppeteer.waitFor(mainPageElements.walletOverview);
-
-    // close popup if present
-    if (
-      (await puppeteer.metamaskWindow().$(mainPageElements.popup.container)) !==
-      null
-    ) {
-      await puppeteer.waitAndClick(mainPageElements.popup.closeButton);
-    }
+    await module.exports.closeMetamaskPopup();
     return true;
   },
   createWallet: async password => {
@@ -108,14 +112,7 @@ module.exports = {
     await puppeteer.waitAndClick(secureYourWalletPageElements.nextButton);
     await puppeteer.waitAndClick(revealSeedPageElements.remindLaterButton);
     await puppeteer.waitFor(mainPageElements.walletOverview);
-
-    // close popup if present
-    if (
-      (await puppeteer.metamaskWindow().$(mainPageElements.popup.container)) !==
-      null
-    ) {
-      await puppeteer.waitAndClick(mainPageElements.popup.closeButton);
-    }
+    await module.exports.closeMetamaskPopup();
     return true;
   },
   importAccount: async privateKey => {

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -69,7 +69,7 @@ module.exports = {
     await puppeteer.waitAndType(unlockPageElements.passwordInput, password);
     await puppeteer.waitAndClick(unlockPageElements.unlockButton);
     await puppeteer.waitFor(mainPageElements.walletOverview);
-    await module.exports.closePopup();
+    await module.exports.closeMetamaskPopup();
     return true;
   },
   importWallet: async (secretWords, password) => {


### PR DESCRIPTION
# Fix Metamask popups after unlock

### The problem

When Metamask popup still open, some methods can fail. 
[`importWallet`](https://github.com/Synthetixio/synpress/blob/dev/commands/metamask.js#L84-L90) and [`createWallet`](https://github.com/Synthetixio/synpress/blob/dev/commands/metamask.js#L112-L118) methods close popups well, but is missing in [`unlock`](https://github.com/Synthetixio/synpress/blob/b3e6f593063f5819e63b4dfebce8359106f2ed4f/commands/metamask.js#L58-L63).

### Solution

Create new `closeMetamaskPopup` method and use it in `importWallet`, `createWallet` and `unlock`.