### PR TITLE
Add Yarn PnP support

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -40,7 +40,7 @@ module.exports = {
     return { networkName, networkId, isTestnet };
   },
   getSynpressPath: () => {
-    return 'node_modules/@synthetixio/synpress';
+    return path.dirname(require.resolve(`@synthetixio/synpress`));
   },
   getMetamaskReleases: async version => {
     let filename;


### PR DESCRIPTION
This will resolve both `node_modules/@synthetixio/synpress` and the [Yarn PnP](https://yarnpkg.com/features/pnp) equivalent, which is something like `.yarn/cache/@synthetixio-synpress-npm-{version&hash}.zip/node_modules/@synthetixio/synpress `.
