### PR TITLE
Fixes race condition when installing MetaMask extension

### DIFF
--- a/support/index.js
+++ b/support/index.js
@@ -24,8 +24,10 @@ Cypress.on('window:before:load', win => {
   });
 });
 
-before(() => {
+before(async function () {
+  this.timeout(60000);
+
   if (!Cypress.env('SKIP_METAMASK_SETUP')) {
-    cy.setupMetamask();
+    await cy.setupMetamask();
   }
 });


### PR DESCRIPTION
The before each hook  for cypress is not awaiting the promise for setting up metamask which leads to a race condition where Metamask is not available before executing the first test