### PR TITLE
fix(puppeteer): using 127.0.0.1 over localhost when fetching debugger…

### DIFF
--- a/commands/puppeteer.js
+++ b/commands/puppeteer.js
@@ -20,7 +20,7 @@ module.exports = {
     return activeTabName;
   },
   init: async () => {
-    const debuggerDetails = await fetch('http://localhost:9222/json/version'); //DevSkim: ignore DS137138
+    const debuggerDetails = await fetch('http://127.0.0.1:9222/json/version'); //DevSkim: ignore DS137138
     const debuggerDetailsConfig = await debuggerDetails.json();
     const webSocketDebuggerUrl = debuggerDetailsConfig.webSocketDebuggerUrl;
 


### PR DESCRIPTION
When trying to debug why I could not get past the setup MetaMask command I realised that an error is being thrown when attempting to fetch the debugger details (fetch("http://localhost:9222/json/version")). By replacing localhost with 127.0.0.1 I was able to resolve the issue and I was able to pass the setup MetaMask command every time. Previously I was only able to run the tests once and it would pass the setup MetaMask command if I had not opened any instance of chrome before. After this it would no longer work so maybe the issue is from having multiple instances of chrome open. 

It would be great to get this PR merged as it has been giving my team and I a lot of headaches recently.