### PR TITLE
Fixed allowMetamaskToAddAndSwitchNetwork

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -694,7 +694,6 @@ module.exports = {
     await playwright.waitAndClick(
       confirmationPageElements.footer.approveButton,
       notificationPage,
-      { waitForEvent: 'close' },
     );
     return true;
   },


### PR DESCRIPTION
I have noticed that after switching to Playwright there are some problems when adding and switching networks - it occur that after adding network Synpress was waiting until the mm window is closed before switching network