### PR TITLE
Default param in allowToAddNetwork to object

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -689,7 +689,7 @@ module.exports = {
     );
     return true;
   },
-  allowToAddNetwork: async ({ waitForEvent }) => {
+  allowToAddNetwork: async ({ waitForEvent } = {}) => {
     const notificationPage = await playwright.switchToMetamaskNotification();
     if (waitForEvent) {
       await playwright.waitAndClick(


### PR DESCRIPTION
I have noticed a bug from this pr https://github.com/Synthetixio/synpress/commit/65254698e1e2a77fc4d1b03b91fb84f4d3c9b281 that breaks addAndSwitchNetwork 
```
CypressError: `cy.task('allowMetamaskToAddAndSwitchNetwork')` failed with the following error:

> Cannot destructure property 'waitForEvent' of 'undefined' as it is undefined.

https://on.cypress.io/api/task
      at <unknown> (http://localhost:3000/__cypress/runner/cypress_runner.js:145679:78)
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:11318:23)
      at Promise._settlePromiseFromHandler (http://localhost:3000/__cypress/runner/cypress_runner.js:9253:31)
      at Promise._settlePromise (http://localhost:3000/__cypress/runner/cypress_runner.js:9310:18)
      at Promise._settlePromise0 (http://localhost:3000/__cypress/runner/cypress_runner.js:9355:10)
      at Promise._settlePromises (http://localhost:3000/__cypress/runner/cypress_runner.js:9431:18)
      at _drainQueueStep (http://localhost:3000/__cypress/runner/cypress_runner.js:6025:12)
      at _drainQueue (http://localhost:3000/__cypress/runner/cypress_runner.js:6018:9)
      at ../../node_modules/bluebird/js/release/async.js.Async._drainQueues (http://localhost:3000/__cypress/runner/cypress_runner.js:6034:5)
      at Async.drainQueues (http://localhost:3000/__cypress/runner/cypress_runner.js:5904:14)
  From Your Spec Code:
      at Context.eval (webpack:///./support/commands.js:151:0)
  
  From Node.js Internals:
    TypeError: Cannot destructure property 'waitForEvent' of 'undefined' as it is undefined.
        at Object.allowToAddNetwork (/Users/willcory/gateway/node_modules/@synthetixio/synpress/commands/metamask.js:692:31)
        at Object.allowToAddAndSwitchNetwork (/Users/willcory/gateway/node_modules/@synthetixio/synpress/commands/metamask.js:736:26)
        at allowMetamaskToAddAndSwitchNetwork (/Users/willcory/gateway/node_modules/@synthetixio/synpress/plugins/index.js:211:38)
        at invoke (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:202:32)
        at <unknown> (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:58:20)
        at tryCatcher (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/node_modules/bluebird/js/release/util.js:16:23)
        at Function.Promise.attempt.Promise.try (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/node_modules/bluebird/js/release/method.js:39:29)
        at Object.wrapChildPromise (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:57:27)
        at RunPlugins.taskExecute (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:206:14)
        at RunPlugins.execute (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:139:29)
        at EventEmitter.<anonymous> (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/child/run_plugins.js:221:19)
        at EventEmitter.emit (node:events:513:28)
        at EventEmitter.emit (node:domain:489:12)
        at process.<anonymous> (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/packages/server/lib/plugins/util.js:32:33)
        at process.emit (node:events:513:28)
        at process.emit (node:domain:489:12)
        at process.emit.sharedData.processEmitHook.installedValue (/Users/willcory/Library/Caches/Cypress/10.8.0/Cypress.app/Contents/Resources/app/node_modules/@cspotcode/source-map-support/source-map-support.js:745:40)
        at process.el [as emit] (/Users/willcory/gateway/node_modules/playwright-core/lib/utilsBundleImpl.js:14:10319)
        at emit (node:internal/child_process:937:14)
        at processTicksAndRejections (node:internal/process/task_queues:83:21)
```