### PR TITLE
docs: addMetamaskNetwork description made clearer

### DIFF
--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -56,7 +56,7 @@ declare namespace Cypress {
      */
     getNetwork(): Chainable<Subject>;
     /**
-     * Add network in metamask
+     * Add network in metamask (and also switch to the newly added network)
      * @example
      * cy.addMetamaskNetwork({networkName: 'name', rpcUrl: 'https://url', chainId: '1', symbol: 'ETH', blockExplorer: 'https://url', isTestnet: true})
      */


### PR DESCRIPTION
Great work with the library :)

While using it, I noticed that the documentation of `addMetamaskNetwork` could've been a little bit clearer - this method not only adds a new network but also switches to it in the process. 

Ideally, this method should also be named just like another method`allowMetamaskToAddAndSwitchNetwork` is named which clearly tells what the function would do.