### PR TITLE
chore: add the docker image platform to be linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM synthetixio/docker-e2e:18.13-ubuntu as base
+FROM --platform=linux/amd64 synthetixio/docker-e2e:18.13-ubuntu as base
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
The [synthetixio/docker-e2e](https://hub.docker.com/r/synthetixio/docker-e2e/tags) only runs on `linux/amd64` machines. 
Which basically will not run directly on `arm64` (M1 / M2 MacBooks). 

As for now the latest version of docker (14.6.2) supports running `linux/amd64` images under **Rosetta 2**

Read this article for more info [Docker on Apple Silicon Mac: How to Run x86 Containers with Rosetta 2](https://levelup.gitconnected.com/docker-on-apple-silicon-mac-how-to-run-x86-containers-with-rosetta-2-4a679913a0d5)  

Adding this flag `--platform=linux/amd64` will automatically run the docker image under **Rosetta 2**. 