### PR TITLE
refactor: replace all `module.exports` with the `this` keyword

### DIFF
--- a/commands/etherscan.js
+++ b/commands/etherscan.js
@@ -16,7 +16,7 @@ module.exports = {
     return { txStatus, txReceipt };
   },
   async waitForTxSuccess(txid) {
-    const txStatus = await module.exports.getTransactionStatus(txid);
+    const txStatus = await this.getTransactionStatus(txid);
     if (
       // status success
       txStatus.txReceipt.result &&
@@ -38,7 +38,7 @@ module.exports = {
       console.log(`Transaction ${txid} is still pending.. waiting..`);
       retries++;
       await sleep(5000);
-      const result = await module.exports.waitForTxSuccess(txid);
+      const result = await this.waitForTxSuccess(txid);
       return result;
     } else {
       retries = 0;

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -75,28 +75,28 @@ const metamask = {
     await playwright.waitUntilStable();
   },
   async goToHome() {
-    await module.exports.goTo(extensionHomeUrl);
+    await this.goTo(extensionHomeUrl);
   },
   async goToSettings() {
-    await module.exports.goTo(extensionSettingsUrl);
+    await this.goTo(extensionSettingsUrl);
   },
   async goToAdvancedSettings() {
-    await module.exports.goTo(extensionAdvancedSettingsUrl);
+    await this.goTo(extensionAdvancedSettingsUrl);
   },
   async goToExperimentalSettings() {
-    await module.exports.goTo(extensionExperimentalSettingsUrl);
+    await this.goTo(extensionExperimentalSettingsUrl);
   },
   async goToAddNetwork() {
-    await module.exports.goTo(extensionAddNetworkUrl);
+    await this.goTo(extensionAddNetworkUrl);
   },
   async goToNewAccount() {
-    await module.exports.goTo(extensionNewAccountUrl);
+    await this.goTo(extensionNewAccountUrl);
   },
   async goToImportAccount() {
-    await module.exports.goTo(extensionImportAccountUrl);
+    await this.goTo(extensionImportAccountUrl);
   },
   async goToImportToken() {
-    await module.exports.goTo(extensionImportTokenUrl);
+    await this.goTo(extensionImportTokenUrl);
   },
   async getExtensionDetails() {
     extensionInitialUrl = await playwright.metamaskWindow().url();
@@ -187,7 +187,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     return true;
   },
   async optOutAnalytics() {
@@ -208,7 +208,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.optOutAnalytics();
+    await this.optOutAnalytics();
     // todo: add support for more secret words (15/18/21/24)
     for (const [index, word] of secretWords.split(' ').entries()) {
       await playwright.waitAndType(
@@ -256,7 +256,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     return true;
   },
   async createWallet(password) {
@@ -267,7 +267,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.optOutAnalytics();
+    await this.optOutAnalytics();
     await playwright.waitAndType(
       firstTimeFlowImportPageElements.passwordInput,
       password,
@@ -310,12 +310,12 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     return true;
   },
   async importAccount(privateKey) {
     await switchToMetamaskIfNotActive();
-    await module.exports.goToImportAccount();
+    await this.goToImportAccount();
     await playwright.waitAndType(
       mainPageElements.importAccount.input,
       privateKey,
@@ -327,7 +327,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -336,7 +336,7 @@ const metamask = {
       accountName = accountName.toLowerCase();
     }
     await switchToMetamaskIfNotActive();
-    await module.exports.goToNewAccount();
+    await this.goToNewAccount();
     if (accountName) {
       await playwright.waitAndType(
         mainPageElements.createAccount.input,
@@ -344,7 +344,7 @@ const metamask = {
       );
     }
     await playwright.waitAndClick(mainPageElements.createAccount.createButton);
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -355,7 +355,7 @@ const metamask = {
     await switchToMetamaskIfNotActive();
     // note: closePopupAndTooltips() is required after changing createAccount() to use direct urls (popup started appearing)
     // ^ this change also introduced 500ms delay for closePopupAndTooltips() function
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await playwright.waitAndClick(mainPageElements.accountMenu.button);
     if (typeof accountNameOrAccountNumber === 'number') {
       await playwright.waitAndClick(
@@ -367,7 +367,7 @@ const metamask = {
         accountNameOrAccountNumber,
       );
     }
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -414,7 +414,7 @@ const metamask = {
       );
     }
     await playwright.waitUntilStable();
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await setNetwork(network);
     await switchToCypressIfNotActive();
     return true;
@@ -440,7 +440,7 @@ const metamask = {
     } else if (typeof network === 'object') {
       network.networkName = network.networkName.toLowerCase();
     }
-    await module.exports.goToAddNetwork();
+    await this.goToAddNetwork();
     await playwright.waitAndType(
       addNetworkPageElements.networkNameInput,
       network.networkName,
@@ -472,7 +472,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await setNetwork(network);
     await playwright.waitForText(
       mainPageElements.networkSwitcher.networkName,
@@ -507,7 +507,7 @@ const metamask = {
         '[disconnectWalletFromDapp] Wallet is not connected to a dapp, skipping..',
       );
     }
-    await module.exports.closeModal();
+    await this.closeModal();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -538,7 +538,7 @@ const metamask = {
         '[disconnectWalletFromAllDapps] Wallet is not connected to any dapps, skipping..',
       );
     }
-    await module.exports.closeModal();
+    await this.closeModal();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -601,7 +601,7 @@ const metamask = {
   },
   async resetAccount() {
     await switchToMetamaskIfNotActive();
-    await module.exports.goToAdvancedSettings();
+    await this.goToAdvancedSettings();
     await playwright.waitAndClick(advancedPageElements.resetAccountButton);
     await playwright.waitAndClick(resetAccountModalElements.resetButton);
     await playwright.waitAndClick(
@@ -611,7 +611,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     return true;
   },
@@ -676,7 +676,7 @@ const metamask = {
   async importToken(tokenConfig) {
     let tokenData = {};
     await switchToMetamaskIfNotActive();
-    await module.exports.goToImportToken();
+    await this.goToImportToken();
     if (typeof tokenConfig === 'string') {
       await playwright.waitAndType(
         mainPageElements.importToken.tokenContractAddressInput,
@@ -729,7 +729,7 @@ const metamask = {
         waitForEvent: 'navi',
       },
     );
-    await module.exports.closePopupAndTooltips();
+    await this.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     tokenData.imported = true;
     return tokenData;
@@ -806,7 +806,7 @@ const metamask = {
         notificationPage,
         { waitForEvent: 'navi' },
       );
-      await module.exports.confirmSignatureRequest();
+      await this.confirmSignatureRequest();
     } else {
       await playwright.waitAndClick(
         permissionsPageElements.connectButton,
@@ -1121,8 +1121,8 @@ const metamask = {
     return true;
   },
   async allowToAddAndSwitchNetwork() {
-    await module.exports.allowToAddNetwork();
-    await module.exports.allowToSwitchNetwork();
+    await this.allowToAddNetwork();
+    await this.allowToSwitchNetwork();
     return true;
   },
   async getWalletAddress() {
@@ -1160,7 +1160,7 @@ const metamask = {
     }
     await playwright.assignWindows();
     await playwright.assignActiveTabName('metamask');
-    await module.exports.getExtensionDetails();
+    await this.getExtensionDetails();
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
     if (
@@ -1171,21 +1171,21 @@ const metamask = {
     ) {
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words
-        await module.exports.importWallet(secretWordsOrPrivateKey, password);
+        await this.importWallet(secretWordsOrPrivateKey, password);
       } else {
         // private key
-        await module.exports.createWallet(password);
-        await module.exports.importAccount(secretWordsOrPrivateKey);
+        await this.createWallet(password);
+        await this.importAccount(secretWordsOrPrivateKey);
       }
 
       await setupSettings(enableAdvancedSettings, enableExperimentalSettings);
 
       if (isCustomNetwork) {
-        await module.exports.addNetwork(network);
+        await this.addNetwork(network);
       } else {
-        await module.exports.changeNetwork(network);
+        await this.changeNetwork(network);
       }
-      walletAddress = await module.exports.getWalletAddress();
+      walletAddress = await this.getWalletAddress();
       await playwright.switchToCypressWindow();
       return true;
     } else if (
@@ -1194,8 +1194,8 @@ const metamask = {
         .locator(unlockPageElements.passwordInput)
         .isVisible()
     ) {
-      await module.exports.unlock(password);
-      walletAddress = await module.exports.getWalletAddress();
+      await this.unlock(password);
+      walletAddress = await this.getWalletAddress();
       await playwright.switchToCypressWindow();
       return true;
     } else {
@@ -1207,7 +1207,7 @@ const metamask = {
         !process.env.RESET_METAMASK
       ) {
         await switchToMetamaskIfNotActive();
-        walletAddress = await module.exports.getWalletAddress();
+        walletAddress = await this.getWalletAddress();
         await playwright.switchToCypressWindow();
         return true;
       } else {

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -94,18 +94,18 @@ module.exports = {
   async switchToCypressWindow() {
     if (mainWindow) {
       await mainWindow.bringToFront();
-      await module.exports.assignActiveTabName('cypress');
+      await this.assignActiveTabName('cypress');
     }
     return true;
   },
   async switchToMetamaskWindow() {
     await metamaskWindow.bringToFront();
-    await module.exports.assignActiveTabName('metamask');
+    await this.assignActiveTabName('metamask');
     return true;
   },
   async switchToMetamaskNotificationWindow() {
     await metamaskNotificationWindow.bringToFront();
-    await module.exports.assignActiveTabName('metamask-notif');
+    await this.assignActiveTabName('metamask-notif');
     return true;
   },
   async switchToMetamaskNotification() {
@@ -115,8 +115,8 @@ module.exports = {
         metamaskNotificationWindow = page;
         retries = 0;
         await page.bringToFront();
-        await module.exports.waitUntilStable(page);
-        await module.exports.waitFor(
+        await this.waitUntilStable(page);
+        await this.waitFor(
           notificationPageElements.notificationAppContent,
           page,
         );
@@ -126,7 +126,7 @@ module.exports = {
     await sleep(200);
     if (retries < 50) {
       retries++;
-      return await module.exports.switchToMetamaskNotification();
+      return await this.switchToMetamaskNotification();
     } else if (retries >= 50) {
       retries = 0;
       throw new Error(
@@ -135,7 +135,7 @@ module.exports = {
     }
   },
   async waitFor(selector, page = metamaskWindow) {
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
     await page.waitForSelector(selector, { strict: false });
     const element = page.locator(selector).first();
     await element.waitFor();
@@ -150,7 +150,7 @@ module.exports = {
     return element;
   },
   async waitAndClick(selector, page = metamaskWindow, args = {}) {
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     if (args.numberOfClicks && !args.waitForEvent) {
       await element.click({
         clickCount: args.numberOfClicks,
@@ -176,25 +176,25 @@ module.exports = {
     } else {
       await element.click({ force: args.force });
     }
-    await module.exports.waitUntilStable();
+    await this.waitUntilStable();
     return element;
   },
   async waitAndClickByText(selector, text, page = metamaskWindow) {
-    await module.exports.waitFor(selector, page);
+    await this.waitFor(selector, page);
     const element = page.locator(`text=${text}`);
     await element.click();
-    await module.exports.waitUntilStable();
+    await this.waitUntilStable();
   },
   async waitAndType(selector, value, page = metamaskWindow) {
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     await element.type(value);
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
   },
   async waitAndGetValue(selector, page = metamaskWindow) {
     const expect = global.expect
       ? global.expect
       : require('@playwright/test').expect;
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     await expect(element).toHaveText(/[a-zA-Z0-9]/, {
       ignoreCase: true,
       useInnerText: true,
@@ -206,7 +206,7 @@ module.exports = {
     const expect = global.expect
       ? global.expect
       : require('@playwright/test').expect;
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     await expect(element).toHaveValue(/[a-zA-Z1-9]/);
     const value = await element.inputValue();
     return value;
@@ -215,36 +215,36 @@ module.exports = {
     const expect = global.expect
       ? global.expect
       : require('@playwright/test').expect;
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     await expect(element).toHaveAttribute(attribute, /[a-zA-Z0-9]/);
     const attrValue = await element.getAttribute(attribute);
     return attrValue;
   },
   async waitAndSetValue(text, selector, page = metamaskWindow) {
-    const element = await module.exports.waitFor(selector, page);
+    const element = await this.waitFor(selector, page);
     await element.fill('');
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
     await element.fill(text);
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
   },
   async waitAndClearWithBackspace(selector, page = metamaskWindow) {
-    await module.exports.waitFor(selector, page);
+    await this.waitFor(selector, page);
     const inputValue = await page.evaluate(selector, el => el.value);
     for (let i = 0; i < inputValue.length; i++) {
       await page.keyboard.press('Backspace');
-      await module.exports.waitUntilStable(page);
+      await this.waitUntilStable(page);
     }
   },
   async waitClearAndType(text, selector, page = metamaskWindow) {
-    const element = await module.exports.waitAndClick(selector, page, {
+    const element = await this.waitAndClick(selector, page, {
       numberOfClicks: 3,
     });
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
     await element.type(text);
-    await module.exports.waitUntilStable(page);
+    await this.waitUntilStable(page);
   },
   async waitForText(selector, text, page = metamaskWindow) {
-    await module.exports.waitFor(selector, page);
+    await this.waitFor(selector, page);
     const element = page.locator(selector, { hasText: text });
     await element.waitFor();
   },
@@ -255,7 +255,7 @@ module.exports = {
       if ((await element.isVisible()) && retries < 300) {
         retries++;
         await page.waitForTimeout(200);
-        await module.exports.waitToBeHidden(selector, page);
+        await this.waitToBeHidden(selector, page);
       } else if (retries >= 300) {
         retries = 0;
         throw new Error(
@@ -270,12 +270,12 @@ module.exports = {
       await page.waitForLoadState('load');
       await page.waitForLoadState('domcontentloaded');
       await page.waitForLoadState('networkidle');
-      await module.exports.waitUntilNotificationWindowIsStable();
+      await this.waitUntilNotificationWindowIsStable();
     }
     await metamaskWindow.waitForLoadState('load');
     await metamaskWindow.waitForLoadState('domcontentloaded');
     await metamaskWindow.waitForLoadState('networkidle');
-    await module.exports.waitUntilMetamaskWindowIsStable();
+    await this.waitUntilMetamaskWindowIsStable();
     if (mainWindow) {
       await mainWindow.waitForLoadState('load');
       await mainWindow.waitForLoadState('domcontentloaded');
@@ -284,34 +284,25 @@ module.exports = {
     }
   },
   async waitUntilNotificationWindowIsStable(page = metamaskNotificationWindow) {
-    await module.exports.waitToBeHidden(
-      notificationPageElements.loadingLogo,
-      page,
-    );
-    await module.exports.waitToBeHidden(
-      notificationPageElements.loadingSpinner,
-      page,
-    );
+    await this.waitToBeHidden(notificationPageElements.loadingLogo, page);
+    await this.waitToBeHidden(notificationPageElements.loadingSpinner, page);
   },
   async waitUntilMetamaskWindowIsStable(page = metamaskWindow) {
-    await module.exports.waitToBeHidden(pageElements.loadingLogo, page); // shown on reload
-    await module.exports.waitToBeHidden(pageElements.loadingSpinner, page); // shown on reload
-    await module.exports.waitToBeHidden(pageElements.loadingOverlay, page); // shown on change network
-    await module.exports.waitToBeHidden(
-      pageElements.loadingOverlaySpinner,
-      page,
-    ); // shown on balance load
+    await this.waitToBeHidden(pageElements.loadingLogo, page); // shown on reload
+    await this.waitToBeHidden(pageElements.loadingSpinner, page); // shown on reload
+    await this.waitToBeHidden(pageElements.loadingOverlay, page); // shown on change network
+    await this.waitToBeHidden(pageElements.loadingOverlaySpinner, page); // shown on balance load
     // network error handler
     if (
       await page.locator(pageElements.loadingOverlayErrorButtons).isVisible()
     ) {
-      await module.exports.waitAndClick(
+      await this.waitAndClick(
         pageElements.loadingOverlayErrorButtonsRetryButton,
         page,
       );
-      await module.exports.waitToBeHidden(pageElements.loadingOverlay, page);
+      await this.waitToBeHidden(pageElements.loadingOverlay, page);
     }
-    await module.exports.fixCriticalError();
+    await this.fixCriticalError();
   },
   // workaround for metamask random blank page on first run
   async fixBlankPage(page = metamaskWindow) {
@@ -320,7 +311,7 @@ module.exports = {
         (await page.locator(onboardingWelcomePageElements.app).count()) === 0
       ) {
         await page.reload();
-        await module.exports.waitUntilMetamaskWindowIsStable();
+        await this.waitUntilMetamaskWindowIsStable();
       } else {
         break;
       }
@@ -332,9 +323,7 @@ module.exports = {
         if (times < 3) {
           await page.reload();
         } else {
-          await module.exports.waitAndClick(
-            pageElements.criticalErrorRestartButton,
-          );
+          await this.waitAndClick(pageElements.criticalErrorRestartButton);
         }
         await module.exports.waitUntilMetamaskWindowIsStable();
       } else {


### PR DESCRIPTION
## Motivation and context

We are using `module.exports` whenever we want to call a function inside the exported object. the `this` keyword is most suited for this use case. 


## Other useful info

I remember fixing it once in the past but didn't know what happened 🤔 

## Quality checklist

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.
