### PR TITLE
deps: add `wait-for-expect` package to the deps

### DIFF
--- a/examples/playwright/fixtures.ts
+++ b/examples/playwright/fixtures.ts
@@ -31,6 +31,7 @@ export const test = base.extend<{
       network: 'sepolia',
       password: 'Tester@1234',
       enableAdvancedSettings: true,
+      enableExperimentalSettings: false,
     });
     await use(context);
     if (!process.env.SERIAL_MODE) {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "prettier": "^2.8.4",
     "serve": "^14.2.0",
     "start-server-and-test": "^2.0.0",
-    "synthetix-js": "^2.74.1"
+    "synthetix-js": "^2.74.1",
+    "wait-for-expect": "^3.0.2"
   },
   "devDependencies": {
     "@metamask/test-dapp": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12923,6 +12923,11 @@ vm2@^3.9.8:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 wait-on@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-7.0.1.tgz#5cff9f8427e94f4deacbc2762e6b0a489b19eae9"


### PR DESCRIPTION
## Motivation and context

In `examples/playwright/fixtures.ts`, there is an error complaining that `wait-for-expect` is not installed. 

```ts
import waitForExpect from 'wait-for-expect'; // <---- line:3 
```

This PR adds this package to the dependencies & fixes the typescript error 


## Quality checklist

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.
