### PR TITLE
Methods to approve access to single and all  collectibles as well as …

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -778,6 +778,32 @@ const metamask = {
     );
     return true;
   },
+  async confirmPermisionToApproveAll() {
+    const notificationPage = await playwright.switchToMetamaskNotification();
+    await playwright.waitAndClick(
+      notificationPageElements.allowToSpendButton,
+      notificationPage,
+    );
+    await playwright.waitAndClick(
+      notificationPageElements.approveWarningToSpendButton,
+      notificationPage,
+      { waitForEvent: 'close' },
+    );
+    return true;
+  },
+  async rejectPermisionToApproveAll() {
+    const notificationPage = await playwright.switchToMetamaskNotification();
+    await playwright.waitAndClick(
+      notificationPageElements.allowToSpendButton,
+      notificationPage,
+    );
+    await playwright.waitAndClick(
+      notificationPageElements.rejectWarningToSpendButton,
+      notificationPage,
+      { waitForEvent: 'close' },
+    );
+    return true;
+  },
   async rejectPermissionToSpend() {
     const notificationPage = await playwright.switchToMetamaskNotification();
     await playwright.waitAndClick(

--- a/pages/metamask/notification-page.js
+++ b/pages/metamask/notification-page.js
@@ -7,6 +7,9 @@ const customSpendingLimitInput = `${notificationPage} [data-testid="custom-spend
 const allowToSpendButton = `${notificationPage} [data-testid="page-container-footer-next"]`;
 const rejectToSpendButton = `${notificationPage} [data-testid="page-container-footer-cancel"]`;
 const selectAllCheckbox = `${notificationPage} .choose-account-list__header-check-box`;
+const approveWarningToSpendButton = `${notificationPage} .set-approval-for-all-warning__footer__approve-button`;
+const rejectWarningToSpendButton = `${notificationPage} .btn-secondary.set-approval-for-all-warning__footer__cancel-button`;
+
 module.exports.notificationPageElements = {
   notificationPage,
   notificationAppContent,
@@ -17,6 +20,8 @@ module.exports.notificationPageElements = {
   allowToSpendButton,
   rejectToSpendButton,
   selectAllCheckbox,
+  approveWarningToSpendButton,
+  rejectWarningToSpendButton,
 };
 
 const confirmSignatureRequestButton = `${notificationPage} .request-signature__footer__sign-button`;

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -215,6 +215,14 @@ module.exports = (on, config) => {
       const confirmed = await metamask.confirmPermissionToSpend(spendLimit);
       return confirmed;
     },
+    confirmPermisionToApproveAll: async () => {
+      const confirmed = await metamask.confirmPermisionToApproveAll();
+      return confirmed;
+    },
+    rejectPermisionToApproveAll: async () => {
+      const confirmed = await metamask.rejectPermisionToApproveAll();
+      return confirmed;
+    },
     rejectMetamaskPermissionToSpend: async () => {
       const rejected = await metamask.rejectPermissionToSpend();
       return rejected;

--- a/support/commands.js
+++ b/support/commands.js
@@ -180,6 +180,14 @@ Cypress.Commands.add('rejectMetamaskPermissionToSpend', () => {
   return cy.task('rejectMetamaskPermissionToSpend');
 });
 
+Cypress.Commands.add('rejectPermisionToApproveAll', () => {
+  return cy.task('rejectPermisionToApproveAll');
+});
+
+Cypress.Commands.add('confirmPermisionToApproveAll', () => {
+  return cy.task('confirmPermisionToApproveAll');
+});
+
 Cypress.Commands.add('acceptMetamaskAccess', options => {
   return cy.task('acceptMetamaskAccess', options);
 });

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -248,6 +248,18 @@ declare namespace Cypress {
      */
     confirmMetamaskPermissionToSpend(spendLimit?: string): Chainable<Subject>;
     /**
+     * Confirm metamask permission to access all elements (example: collectibles)
+     * @example
+     * cy.confirmPermisionToApproveAll()
+     */
+    confirmPermisionToApproveAll(): Chainable<Subject>;
+    /**
+     * Reject metamask permission to access all elements (example: collectibles)
+     * @example
+     * cy.rejectPermisionToApproveAll()
+     */
+    rejectPermisionToApproveAll(): Chainable<Subject>;
+    /**
      * Reject metamask permission to spend asset
      * @example
      * cy.rejectMetamaskPermissionToSpend()

--- a/tests/e2e/specs/metamask-spec.js
+++ b/tests/e2e/specs/metamask-spec.js
@@ -103,6 +103,22 @@ describe('Metamask', () => {
         expect(network.isTestnet).to.be.true;
       });
     });
+    it(`rejectPermisionToApproveAll should reject permission to approve all collectibles upon warning`, () => {
+      cy.get('#deployCollectiblesButton').click();
+      cy.confirmMetamaskTransaction();
+      cy.get('#mintButton').click();
+      cy.confirmMetamaskTransaction();
+      cy.get('#setApprovalForAllButton').click();
+      cy.rejectPermisionToApproveAll().then(rejected => {
+        expect(rejected).to.be.true;
+      });
+    });
+    it(`confirmPermisionToApproveAll should confirm permission to approve all collectibles`, () => {
+      cy.get('#setApprovalForAllButton').click();
+      cy.confirmPermisionToApproveAll().then(confirmed => {
+        expect(confirmed).to.be.true;
+      });
+    });
     it(`changeMetamaskNetwork should change network using custom network name`, () => {
       if (Cypress.env('USE_ANVIL')) {
         cy.changeMetamaskNetwork('anvil').then(networkChanged => {


### PR DESCRIPTION
…rejecting access have been added

## Motivation and context

Clearly and concisely describe the feature added/issues being solved.

I have added the ability to approve all collectibles access, since the current confirmMetamaskToSpend method did not have this scenario covered, and it shows a warning when attempting to give access to it. these scenarios and changes should have been working.

## Does it fix any issue?
Not an issue yet, but it was a discussion:
https://github.com/Synthetixio/synpress/discussions/730
#(issue)

## Other useful info

N/A

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.
