### PR TITLE
Added web3-mock dependency, currently returning an error at ethers level

### DIFF
--- a/tests/e2e/specs/web3-mock-spec.js
+++ b/tests/e2e/specs/web3-mock-spec.js
@@ -1,0 +1,21 @@
+import { Mock } from '@depay/web3-mock';
+
+/* eslint-disable ui-testing/no-disabled-tests */
+describe('Metamask', () => {
+  context('Test commands', () => {
+    beforeEach(() => {
+      Mock.mock(window); // This is a very simplified example, we still need to mock specific behaviors.
+    });
+    // todo: clear the state of extension and test different combinations of setupMetamask with private key & custom network
+    it(`setupMetamask should finish metamask setup using secret words`, () => {
+      cy.setupMetamask(
+        'test test test test test test test test test test test junk',
+        'sepolia',
+        'Tester@1234',
+      ).then(setupFinished => {
+        expect(setupFinished).to.be.true;
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
## Motivation and context

We need to add web3-Mock support from @Depay in order to mock metamask responses, thus giving us more flexibility at the time of creating edge case scenarios.

## Does it fix any issue?

#(issue)

## Other useful info

It is currently unable to run the test cases due to the imports and the beforeAll method code, it is failing at a webpack level.

Error is:
Error: Webpack Compilation Error
./node_modules/ethers/lib.commonjs/abi/abi-coder.js 112:4
Module parse failed: Unexpected character '#' (112:4)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   */
| class AbiCoder {
>     #getCoder(param) {
|         if (param.isArray()) {
|             return new array_js_1.ArrayCoder(this.#getCoder(param.arrayChildren), param.arrayLength, param.name);
 @ ./node_modules/ethers/lib.commonjs/abi/index.js 11:21-46
 @ ./node_modules/ethers/lib.commonjs/ethers.js
 @ ./node_modules/ethers/lib.commonjs/index.js
 @ ./node_modules/@depay/web3-mock/dist/umd/index.js
 @ ./tests/e2e/specs/web3-mock-spec.js

## Quality checklist

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
