### PR TITLE
Added fix after adding and switching network

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1230,9 +1230,11 @@ const metamask = {
       { waitForEvent: 'close' },
     );
     await switchToMetamaskIfNotActive();
-    await playwright.waitAndClick(
-      recipientPopupElements.popupCloseButton,
-    )
+    if (recipientPopupElements.popupCloseButton) {
+      await playwright.waitAndClick(
+        recipientPopupElements.popupCloseButton,
+      )
+    }
     await module.exports.closePopupAndTooltips();
     await switchToCypressIfNotActive();
     return true;

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1229,6 +1229,12 @@ const metamask = {
       notificationPage,
       { waitForEvent: 'close' },
     );
+    await switchToMetamaskIfNotActive();
+    await playwright.waitAndClick(
+      recipientPopupElements.popupCloseButton,
+    )
+    await module.exports.closePopupAndTooltips();
+    await switchToCypressIfNotActive();
     return true;
   },
   async rejectToSwitchNetwork() {

--- a/pages/metamask/notification-page.js
+++ b/pages/metamask/notification-page.js
@@ -54,13 +54,13 @@ const popupContainer = '.popover-container';
 const popupCloseButton = `${popupContainer} .popover-header__button`;
 const popupCopyRecipientPublicAddressButton = `${popupContainer} .nickname-popover__public-address button`;
 const recipientPublicAddress = `${popupContainer} .nickname-popover__public-address__constant`;
-const gotItButton = `${popupContainer} .btn-primary`
+const popupGotItButton = `${popupContainer} .btn-primary`
 module.exports.recipientPopupElements = {
   popupContainer,
   popupCloseButton,
   popupCopyRecipientPublicAddressButton,
   recipientPublicAddress,
-  gotItButton,
+  popupGotItButton,
 };
 
 const confirmPageHeader = `${notificationPage} .confirm-page-container-header`;

--- a/pages/metamask/notification-page.js
+++ b/pages/metamask/notification-page.js
@@ -54,11 +54,13 @@ const popupContainer = '.popover-container';
 const popupCloseButton = `${popupContainer} .popover-header__button`;
 const popupCopyRecipientPublicAddressButton = `${popupContainer} .nickname-popover__public-address button`;
 const recipientPublicAddress = `${popupContainer} .nickname-popover__public-address__constant`;
+const gotItButton = `${popupContainer} .btn-primary`
 module.exports.recipientPopupElements = {
   popupContainer,
   popupCloseButton,
   popupCopyRecipientPublicAddressButton,
   recipientPublicAddress,
+  gotItButton,
 };
 
 const confirmPageHeader = `${notificationPage} .confirm-page-container-header`;


### PR DESCRIPTION
## Motivation and context

An issue was reported where the action allowToAddAndSwitchNetwork was working as expected, however, there was a pop-up being displayed afterward that we did not handle and was not able to interact with the Metamask popup.
![image](https://github.com/Synthetixio/synpress/assets/10635675/89da1e40-6aa2-4d29-ba83-d584cb3733eb)

This new step opens up the Metamask notification, clicks on the got it button, and closes the Metamask notification screen.

#761

## Quality checklist

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.

