### PR TITLE
Use network object when .env variables are complete in setupMetamask

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -270,6 +270,29 @@ module.exports = (on, config) => {
       if (process.env.NETWORK_NAME) {
         network = process.env.NETWORK_NAME;
       }
+      if (
+        process.env.NETWORK_NAME &&
+        process.env.RPC_URL &&
+        process.env.CHAIN_ID &&
+        process.env.SYMBOL
+      ) {
+        network = {
+          id: process.env.CHAIN_ID,
+          name: process.env.NETWORK_NAME,
+          nativeCurrency: {
+            symbol: process.env.SYMBOL,
+          },
+          rpcUrls: {
+            public: { http: [process.env.RPC_URL] },
+            default: { http: [process.env.RPC_URL] },
+          },
+          blockExplorers: {
+            etherscan: { url: process.env.BLOCK_EXPLORER },
+            default: { url: process.env.BLOCK_EXPLORER },
+          },
+          testnet: process.env.IS_TESTNET,
+        };
+      }
       if (process.env.PRIVATE_KEY) {
         secretWordsOrPrivateKey = process.env.PRIVATE_KEY;
       }


### PR DESCRIPTION
## Motivation and context

For fixing https://github.com/Synthetixio/synpress/issues/764

This will make it so that network is passed as an object instead of just the network name in `setupMetamask`

## Does it fix any issue?

#([issue](https://github.com/Synthetixio/synpress/issues/764))

## Other useful info

N/A

## Quality checklist

- [ x ] I have performed a self-review of my code.
- [ x] If it is a core feature, I have added thorough e2e tests.
