### PR TITLE
feat: clear extension data

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     commonjs: true,
     es2021: true,
     'cypress/globals': true,
+    webextensions: true,
   },
   extends: [
     'eslint:recommended',

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -56,6 +56,35 @@ module.exports = {
     }
     return browser.isConnected();
   },
+  async clearExtensionData() {
+    try {
+      await module.exports.metamaskWindow().evaluate(async () => {
+        await new Promise((resolve, reject) => {
+          return chrome.storage.local.clear(() => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(true);
+            }
+          });
+        });
+
+        await new Promise((resolve, reject) => {
+          return chrome.storage.sync.clear(() => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(true);
+            }
+          });
+        });
+      });
+
+      await module.exports.metamaskWindow().reload();
+    } catch (error) {
+      console.log(`[clearExtensionData] ${error.message}`);
+    }
+  },
   async clear() {
     browser = null;
     return true;


### PR DESCRIPTION
## Motivation and context

ATM, there is no way to reset the MetaMask state between tests. Being able to reset MetaMask (when needed) will prevent tests from interfering with its others. 

## Other useful info

This change is inspired by this PR https://github.com/Synthetixio/synpress/pull/698 (Support Phantom Wallet)

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.
