### PR TITLE
fix: inconsistent behavior in initialSetup when using another extension

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1299,24 +1299,13 @@ const metamask = {
         await playwright.switchToCypressWindow();
         return true;
       } else {
-        console.log('end');
-        if (playwrightInstance) {
-          console.log('0');
-          await playwright.init(playwrightInstance);
-          console.log('1');
-        } else {
-          await playwright.init();
-        }
-        await playwright.assignWindows();
-        await playwright.assignActiveTabName('metamask');
-        await module.exports.getExtensionDetails();
-        await playwright.fixBlankPage();
-        await playwright.fixCriticalError();
-        await switchToMetamaskIfNotActive();
-        walletAddress = await module.exports.getWalletAddress();
-        await playwright.switchToCypressWindow();
-        console.log('swithc');
-        return true;
+        return await this.initialSetup(playwright, {
+          secretWordsOrPrivateKey,
+          network,
+          password,
+          enableAdvancedSettings,
+          enableExperimentalSettings,
+        });
       }
     }
   },

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1252,11 +1252,17 @@ const metamask = {
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
     console.log('two');
-    const temp = playwright
-      .metamaskWindow()
-      .locator(onboardingWelcomePageElements.onboardingWelcomePage);
-    await temp.waitFor({ timeout: 10000 });
-    if (temp.count() > 0) {
+    if (
+      (await playwright
+        .metamaskWindow()
+        .locator(onboardingWelcomePageElements.onboardingWelcomePage)
+        .count()) > 0 ||
+      (await playwright
+        .metamaskWindow()
+        .locator('button')
+        .getByText('Import an existing wallet')
+        .count()) > 0
+    ) {
       console.log('three');
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1304,6 +1304,7 @@ const metamask = {
         await switchToMetamaskIfNotActive();
         walletAddress = await module.exports.getWalletAddress();
         await playwright.switchToCypressWindow();
+        console.log('swithc');
         return true;
       }
     }

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,13 +1300,10 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        return await module.exports.initialSetup(undefined, {
-          secretWordsOrPrivateKey,
-          network,
-          password,
-          enableAdvancedSettings,
-          enableExperimentalSettings,
-        });
+        await switchToMetamaskIfNotActive();
+        walletAddress = await module.exports.getWalletAddress();
+        await playwright.switchToCypressWindow();
+        return true;
       }
     }
   },

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1301,6 +1301,10 @@ const metamask = {
       } else {
         console.log('end');
         // todo: reset metamask state
+        await switchToMetamaskIfNotActive();
+        walletAddress = await module.exports.getWalletAddress();
+        await playwright.switchToCypressWindow();
+        return true;
       }
     }
   },

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,7 +1300,7 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        return await module.exports.initialSetup(playwright, {
+        return await module.exports.initialSetup({
           secretWordsOrPrivateKey,
           network,
           password,

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,7 +1300,18 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        // todo: reset metamask state
+        if (playwrightInstance) {
+          console.log('0');
+          await playwright.init(playwrightInstance);
+          console.log('1');
+        } else {
+          await playwright.init();
+        }
+        await playwright.assignWindows();
+        await playwright.assignActiveTabName('metamask');
+        await module.exports.getExtensionDetails();
+        await playwright.fixBlankPage();
+        await playwright.fixCriticalError();
         await switchToMetamaskIfNotActive();
         walletAddress = await module.exports.getWalletAddress();
         await playwright.switchToCypressWindow();

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1299,6 +1299,7 @@ const metamask = {
         await playwright.switchToCypressWindow();
         return true;
       } else {
+        console.log('end');
         // todo: reset metamask state
       }
     }

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1252,7 +1252,20 @@ const metamask = {
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
     console.log('two');
-    console.log(playwright.metamaskWindow());
+    console.log(
+      await playwright
+        .metamaskWindow()
+        .locator('button')
+        .getByText('Import an existing wallet')
+        .count(),
+    );
+    console.log(
+      await playwright
+        .mainWindow()
+        .locator('button')
+        .getByText('Import an existing wallet')
+        .count(),
+    );
     if (
       (await playwright
         .metamaskWindow()

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1242,9 +1242,7 @@ const metamask = {
     },
   ) {
     if (playwrightInstance) {
-      console.log('0');
       await playwright.init(playwrightInstance);
-      console.log('1');
     } else {
       await playwright.init();
     }
@@ -1254,12 +1252,12 @@ const metamask = {
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
     console.log('two');
-    if (
-      (await playwright
-        .metamaskWindow()
-        .locator(onboardingWelcomePageElements.onboardingWelcomePage)
-        .count()) > 0
-    ) {
+    const temp = playwright
+      .metamaskWindow()
+      .locator(onboardingWelcomePageElements.onboardingWelcomePage);
+    await temp.waitFor({ timeout: 10000 });
+    if (temp.count() > 0) {
+      console.log('three');
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words
         await module.exports.importWallet(secretWordsOrPrivateKey, password);

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1242,7 +1242,9 @@ const metamask = {
     },
   ) {
     if (playwrightInstance) {
+      console.log('0');
       await playwright.init(playwrightInstance);
+      console.log('1');
     } else {
       await playwright.init();
     }
@@ -1251,6 +1253,7 @@ const metamask = {
     await module.exports.getExtensionDetails();
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
+    console.log('two');
     if (
       (await playwright
         .metamaskWindow()

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,7 +1300,7 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        return await module.exports.initialSetup({
+        return await module.exports.initialSetup(undefined, {
           secretWordsOrPrivateKey,
           network,
           password,

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1299,6 +1299,7 @@ const metamask = {
         await playwright.switchToCypressWindow();
         return true;
       } else {
+        console.log('end');
         return await this.initialSetup(playwright, {
           secretWordsOrPrivateKey,
           network,

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,7 +1300,7 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        return await this.initialSetup(playwright, {
+        return await module.exports.initialSetup(playwright, {
           secretWordsOrPrivateKey,
           network,
           password,

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1260,11 +1260,12 @@ const metamask = {
         .count(),
     );
     console.log(
-      await playwright
-        .mainWindow()
-        .locator('button')
-        .getByText('Import an existing wallet')
-        .count(),
+      playwright.mainWindow() &&
+        (await playwright
+          .mainWindow()
+          .locator('button')
+          .getByText('Import an existing wallet')
+          .count()),
     );
     if (
       (await playwright

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1300,7 +1300,19 @@ const metamask = {
         return true;
       } else {
         console.log('end');
-        await switchToMetamaskIfNotActive();
+        if (secretWordsOrPrivateKey.includes(' ')) {
+          // secret words
+          await module.exports.importWallet(secretWordsOrPrivateKey, password);
+        } else {
+          // private key
+          await module.exports.createWallet(password);
+          await module.exports.importAccount(secretWordsOrPrivateKey);
+        }
+
+        await setupSettings(enableAdvancedSettings, enableExperimentalSettings);
+
+        await module.exports.changeNetwork(network);
+
         walletAddress = await module.exports.getWalletAddress();
         await playwright.switchToCypressWindow();
         return true;

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1251,34 +1251,12 @@ const metamask = {
     await module.exports.getExtensionDetails();
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
-    console.log('two');
-    console.log(
-      await playwright
-        .metamaskWindow()
-        .locator('button')
-        .getByText('Import an existing wallet')
-        .count(),
-    );
-    console.log(
-      playwright.mainWindow() &&
-        (await playwright
-          .mainWindow()
-          .locator('button')
-          .getByText('Import an existing wallet')
-          .count()),
-    );
     if (
       (await playwright
         .metamaskWindow()
         .locator(onboardingWelcomePageElements.onboardingWelcomePage)
-        .count()) > 0 ||
-      (await playwright
-        .metamaskWindow()
-        .locator('button')
-        .getByText('Import an existing wallet')
         .count()) > 0
     ) {
-      console.log('three');
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words
         await module.exports.importWallet(secretWordsOrPrivateKey, password);
@@ -1318,23 +1296,7 @@ const metamask = {
         await playwright.switchToCypressWindow();
         return true;
       } else {
-        console.log('end');
-        if (secretWordsOrPrivateKey.includes(' ')) {
-          // secret words
-          await module.exports.importWallet(secretWordsOrPrivateKey, password);
-        } else {
-          // private key
-          await module.exports.createWallet(password);
-          await module.exports.importAccount(secretWordsOrPrivateKey);
-        }
-
-        await setupSettings(enableAdvancedSettings, enableExperimentalSettings);
-
-        await module.exports.changeNetwork(network);
-
-        walletAddress = await module.exports.getWalletAddress();
-        await playwright.switchToCypressWindow();
-        return true;
+        // todo
       }
     }
   },

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1252,6 +1252,7 @@ const metamask = {
     await playwright.fixBlankPage();
     await playwright.fixCriticalError();
     console.log('two');
+    console.log(playwright.metamaskWindow());
     if (
       (await playwright
         .metamaskWindow()

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1296,7 +1296,7 @@ const metamask = {
         await playwright.switchToCypressWindow();
         return true;
       } else {
-        // todo
+        // todo: reset metamask state
       }
     }
   },

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -69,7 +69,6 @@ module.exports = {
         page.url().includes('extension') &&
         page.url().includes('home.html')
       ) {
-        console.log('url', page.url());
         metamaskWindow = page;
       } else if (page.url().includes('notification')) {
         metamaskNotificationWindow = page;

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -67,7 +67,7 @@ module.exports = {
         mainWindow = page;
       } else if (
         page.url().includes('extension') &&
-        page.url.includes('home.html')
+        page.url().includes('home.html')
       ) {
         console.log('url', page.url());
         metamaskWindow = page;

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -62,10 +62,13 @@ module.exports = {
   },
   async assignWindows() {
     let pages = await browser.contexts()[0].pages();
-    const workers = browser.contexts()[0].serviceWorkers();
-    console.log(`workers`, workers);
+    //const workers = browser.contexts()[0].serviceWorkers();
     for (const page of pages) {
-      console.log(`page`, page);
+      const extensionName = await page.evaluate(async () => {
+        const manifest = await chrome.runtime.getManifest();
+        return manifest.name;
+      });
+      console.log(`extentionName`, extensionName);
       if (page.url().includes('runner')) {
         mainWindow = page;
       } else if (

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -66,6 +66,7 @@ module.exports = {
       if (page.url().includes('runner')) {
         mainWindow = page;
       } else if (page.url().includes('extension')) {
+        console.log('url', page.url());
         metamaskWindow = page;
       } else if (page.url().includes('notification')) {
         metamaskNotificationWindow = page;

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -65,6 +65,7 @@ module.exports = {
     const workers = browser.contexts()[0].serviceWorkers();
     console.log(`workers`, workers);
     for (const page of pages) {
+      console.log(`page`, page);
       if (page.url().includes('runner')) {
         mainWindow = page;
       } else if (

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -65,7 +65,10 @@ module.exports = {
     for (const page of pages) {
       if (page.url().includes('runner')) {
         mainWindow = page;
-      } else if (page.url().includes('extension')) {
+      } else if (
+        page.url().includes('extension') &&
+        page.url.includes('home.html')
+      ) {
         console.log('url', page.url());
         metamaskWindow = page;
       } else if (page.url().includes('notification')) {

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -62,6 +62,8 @@ module.exports = {
   },
   async assignWindows() {
     let pages = await browser.contexts()[0].pages();
+    const workers = browser.contexts()[0].serviceWorkers();
+    console.log(`workers`, workers);
     for (const page of pages) {
       if (page.url().includes('runner')) {
         mainWindow = page;


### PR DESCRIPTION
## Motivation and context

When using another extension in testing the other extension was getting assigned to the metamask window and breaking the tests.  This adds an additional check such that the metamask window will get set correctly

## Does it fix any issue?

#798 

## Quality checklist

- [ x] I have performed a self-review of my code.
- [ x] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
