### PR TITLE
Unskip MetaMask add/switch network tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM --platform=linux/amd64 synthetixio/docker-e2e:18.16-ubuntu as base
 RUN mkdir /app
 WORKDIR /app
 
+RUN apt update && apt install -y nginx
+
+COPY nginx.conf /etc/nginx/sites-available/default
+
 COPY package.json ./
 COPY pnpm-lock.yaml ./
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -116,7 +116,7 @@ services:
   foundry-metamask-test-dapp:
     profiles:
       - foundry
-    container_name: foundry
+    container_name: foundry-metamask-test-dapp
     image: synthetixio/foundry:457bb48776c3b14de232d9dda620ba9188dc40ac-base
     # Port and chain id as required by the MetaMask Test Dapp
     command: [ 'anvil --no-cors --port 8546 --chain-id 1338' ]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -43,7 +43,7 @@ services:
       - ./docker/videos:/app/tests/e2e/videos
       - ./docker/screenshots:/app/tests/e2e/screenshots
     command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && pnpm test:e2e:ci:anvil'
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && nginx && pnpm test:e2e:ci:anvil'
     networks:
       - x11
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -113,5 +113,19 @@ services:
     networks:
       - x11
 
+  foundry-metamask-test-dapp:
+    profiles:
+      - foundry
+    container_name: foundry
+    image: synthetixio/foundry:457bb48776c3b14de232d9dda620ba9188dc40ac-base
+    # Port and chain id as required by the MetaMask Test Dapp
+    command: [ 'anvil --no-cors --port 8546 --chain-id 1338' ]
+    environment:
+      - ANVIL_IP_ADDR=0.0.0.0
+    ports:
+      - '8546:8546'
+    networks:
+      - x11
+
 networks:
   x11:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./docker/videos:/app/tests/e2e/videos
       - ./docker/screenshots:/app/tests/e2e/screenshots
     command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && pnpm test:e2e:anvil'
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && nginx && pnpm test:e2e:anvil'
     networks:
       - x11
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
   foundry-metamask-test-dapp:
     profiles:
       - foundry
-    container_name: foundry
+    container_name: foundry-metamask-test-dapp
     image: synthetixio/foundry:457bb48776c3b14de232d9dda620ba9188dc40ac-base
     # Port and chain id as required by the MetaMask Test Dapp
     command: [ 'anvil --no-cors --port 8546 --chain-id 1338' ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,5 +84,19 @@ services:
     networks:
       - x11
 
+  foundry-metamask-test-dapp:
+    profiles:
+      - foundry
+    container_name: foundry
+    image: synthetixio/foundry:457bb48776c3b14de232d9dda620ba9188dc40ac-base
+    # Port and chain id as required by the MetaMask Test Dapp
+    command: [ 'anvil --no-cors --port 8546 --chain-id 1338' ]
+    environment:
+      - ANVIL_IP_ADDR=0.0.0.0
+    ports:
+      - '8546:8546'
+    networks:
+      - x11
+
 networks:
   x11:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 8545;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://foundry:8545;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 8546;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://foundry-metamask-test-dapp:8546;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/tests/e2e/specs/metamask-spec.js
+++ b/tests/e2e/specs/metamask-spec.js
@@ -58,9 +58,7 @@ describe('Metamask', () => {
       if (Cypress.env('USE_ANVIL')) {
         cy.addMetamaskNetwork({
           networkName: 'anvil',
-          rpcUrl: Cypress.env('DOCKER_RUN')
-            ? 'http://foundry:8545'
-            : 'http://127.0.0.1:8545',
+          rpcUrl: 'http://127.0.0.1:8545',
           chainId: 11155111,
           symbol: 'aETH',
           isTestnet: true,

--- a/tests/e2e/specs/metamask-spec.js
+++ b/tests/e2e/specs/metamask-spec.js
@@ -436,25 +436,24 @@ describe('Metamask', () => {
         expect(approved).to.be.true;
       });
     });
-    // todo: this feature is broken inside test-dapp, needs to be fixed (unable to switch to DAI chain)
-    it.skip(`rejectMetamaskToAddNetwork should reject permission to add network`, () => {
+    it(`rejectMetamaskToAddNetwork should reject permission to add network`, () => {
       cy.get('#addEthereumChain').click();
       cy.rejectMetamaskToAddNetwork().then(rejected => {
         expect(rejected).to.be.true;
       });
     });
-    it.skip(`allowMetamaskToAddNetwork should approve permission to add network`, () => {
+    it(`allowMetamaskToAddNetwork should approve permission to add network`, () => {
       cy.get('#addEthereumChain').click();
-      cy.allowMetamaskToAddNetwork('close').then(approved => {
+      cy.allowMetamaskToAddNetwork().then(approved => {
         expect(approved).to.be.true;
       });
     });
-    it.skip(`rejectMetamaskToSwitchNetwork should reject permission to switch network`, () => {
+    it(`rejectMetamaskToSwitchNetwork should reject permission to switch network`, () => {
       cy.rejectMetamaskToSwitchNetwork().then(rejected => {
         expect(rejected).to.be.true;
       });
     });
-    it.skip(`allowMetamaskToSwitchNetwork should approve permission to switch network`, () => {
+    it(`allowMetamaskToSwitchNetwork should approve permission to switch network`, () => {
       cy.get('#switchEthereumChain').click();
       cy.allowMetamaskToSwitchNetwork().then(approved => {
         expect(approved).to.be.true;


### PR DESCRIPTION
Integrating Nginx allows us to redirect `http://127.0.0.1:8545` calls to `http://foundry:8545` and `http://127.0.0.1:8546` calls to `http://foundry-metamask-test-dapp:8546`. With this, we don't have to worry about conditionally handling RPC URLs or RPC calls to a local node from the MetaMask Test Dap when running tests in docker.