### PR TITLE
Fix: failures on uncaught exception (should use Cypress.env, not process.env)

### DIFF
--- a/support/index.js
+++ b/support/index.js
@@ -5,7 +5,7 @@ configure({ testIdAttribute: 'data-testid' });
 
 // dont fail tests on uncaught exceptions of websites
 Cypress.on('uncaught:exception', () => {
-  if (!process.env.FAIL_ON_ERROR) {
+  if (!Cypress.env('FAIL_ON_ERROR')) {
     return false;
   }
 });
@@ -14,7 +14,7 @@ Cypress.on('window:before:load', win => {
   cy.stub(win.console, 'error').callsFake(message => {
     cy.now('task', 'error', message);
     // fail test on browser console error
-    if (process.env.FAIL_ON_ERROR) {
+    if (Cypress.env('FAIL_ON_ERROR')) {
       throw new Error(message);
     }
   });


### PR DESCRIPTION
## Motivation and context

This is a follow up to https://github.com/Synthetixio/synpress/issues/831: I've stumbled upon another issue that reproducibly produced the `process is not defined` error, applied my suggestion from comments and confirmed that the bug goes away indeed (`process is not defined` is no longer shown, the step passes).

## Quality checklist

- [x] I have performed a self-review of my code.

## Todo

- [ ] Find whether there's a e2e test for this feature, check if it was red before and got green now