### PR TITLE
fix: don't wrap a cy.setupMetamask into a Promise

### DIFF
--- a/support/index.js
+++ b/support/index.js
@@ -24,8 +24,8 @@ Cypress.on('window:before:load', win => {
   });
 });
 
-before(async () => {
+before(() => {
   if (!Cypress.env('SKIP_METAMASK_SETUP')) {
-    await cy.setupMetamask();
+    cy.setupMetamask();
   }
 });


### PR DESCRIPTION
## Motivation and context

This is to fix the problem initially described in [issue 775](https://github.com/Synthetixio/synpress/issues/775). For run mode, it merely removes a warning [due to](https://docs.cypress.io/guides/references/error-messages#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) `setupMetamask` command is wrapped into a `Promise`. For watch mode, it removes one of the issues that breaks it (the one Cypress complains about currently).

## Quality checklist

- [x] I have performed a self-review of my code.
