### PR TITLE
🔧 chore(core): Introduce `tsconfig.build.json`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
   ],
   "scripts": {
     "build": "pnpm run clean && pnpm run build:dist && pnpm run build:types",
-    "build:dist": "tsup",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:dist": "tsup --tsconfig tsconfig.build.json",
+    "build:types": "tsc --emitDeclarationOnly --project tsconfig.build.json",
     "clean": "rimraf dist types",
     "lint": "biome check . --apply",
     "lint:check": "biome check . --verbose",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "types",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,13 +1,10 @@
 {
-  "extends": "tsconfig/base.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "types",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "rootDir": "."
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ]
 }


### PR DESCRIPTION
Thanks to the distinction between `tsconfig.build.json` and `tsconfig.json` we can now have proper type checking by the TypeScript LSP in the `test` directory.

See [this comment](https://github.com/jaredpalmer/tsdx/issues/871#issuecomment-695822562) for a detailed explanation. 
This PR utilizes the `Workaround #2` from the comment above.