### PR TITLE
👷 chore(ci): Archive Playwright traces for E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,12 @@ jobs:
 
       - name: Run E2E tests (headless)
         run: pnpm run test:e2e:headless
+
+      - name: Archive Playwright traces
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: playwright-traces
+          path: |
+            wallets/metamask/test-results
+          if-no-files-found: error

--- a/wallets/metamask/playwright.config.ts
+++ b/wallets/metamask/playwright.config.ts
@@ -17,13 +17,16 @@ export default defineConfig({
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
 
-  // Concise 'dot' for CI, default 'html' when running locally. See https://playwright.dev/docs/test-reporters.
+  // Concise 'dot' for CI, default 'html' when running locally.
+  // See https://playwright.dev/docs/test-reporters.
   reporter: process.env.CI ? 'dot' : 'html',
 
-  // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
+  // Shared settings for all the projects below.
+  // See https://playwright.dev/docs/api/class-testoptions.
   use: {
-    // Collect traces for all failed tests. See https://playwright.dev/docs/trace-viewer.
-    trace: 'retain-on-failure'
+    // Collect all traces on CI, and only traces for failed tests when running locally.
+    // See https://playwright.dev/docs/trace-viewer.
+    trace: process.env.CI ? 'on' : 'retain-on-failure'
   },
 
   // Configure projects for major browsers.


### PR DESCRIPTION
UX of unzipping the artifact once downloaded is not ideal, but it should be enough for now.