### PR TITLE
Fix localized Chrome's extension id

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -123,10 +123,7 @@ const metamask = {
     const metamaskExtensionData = (await playwright.getExtensionsData())
       .metamask;
 
-    // Handle cases where the extension id is prefixed with the localized `Identifier: ` string
-    extensionId = metamaskExtensionData.id.includes(': ')
-      ? metamaskExtensionData.id.split(': ')[1]
-      : metamaskExtensionData.id;
+    extensionId = metamaskExtensionData.id;
     extensionVersion = metamaskExtensionData.version;
     extensionHomeUrl = `chrome-extension://${extensionId}/home.html`;
     extensionSettingsUrl = `${extensionHomeUrl}#settings`;

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -123,7 +123,10 @@ const metamask = {
     const metamaskExtensionData = (await playwright.getExtensionsData())
       .metamask;
 
-    extensionId = metamaskExtensionData.id;
+    // Handle cases where the extension id is prefixed with the localized `Identifier: ` string
+    extensionId = metamaskExtensionData.id.includes(': ')
+      ? metamaskExtensionData.id.split(': ')[1]
+      : metamaskExtensionData.id;
     extensionVersion = metamaskExtensionData.version;
     extensionHomeUrl = `chrome-extension://${extensionId}/home.html`;
     extensionSettingsUrl = `${extensionHomeUrl}#settings`;

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -60,10 +60,7 @@ module.exports = {
   async metamaskExtensionId() {
     const metamaskExtensionData = (await module.exports.getExtensionsData())
     .metamask;
-    // Handle cases where the extension id is prefixed with the localized `Identifier: ` string
-    return metamaskExtensionData.id.includes(': ')
-      ? metamaskExtensionData.id.split(': ')[1]
-      : metamaskExtensionData.id;
+    return metamaskExtensionData.id;
   },
   async setExpectInstance(expect) {
     expectInstance = expect;
@@ -482,7 +479,7 @@ module.exports = {
 
       const extensionId = (
         await extensionData.locator('#extension-id').textContent()
-      ).replace('ID: ', '');
+      ).split(': ')[1];
 
       extensionsData[extensionName] = {
         version: extensionVersion,

--- a/commands/playwright.js
+++ b/commands/playwright.js
@@ -57,6 +57,14 @@ module.exports = {
   activeTabName() {
     return activeTabName;
   },
+  async metamaskExtensionId() {
+    const metamaskExtensionData = (await module.exports.getExtensionsData())
+    .metamask;
+    // Handle cases where the extension id is prefixed with the localized `Identifier: ` string
+    return metamaskExtensionData.id.includes(': ')
+      ? metamaskExtensionData.id.split(': ')[1]
+      : metamaskExtensionData.id;
+  },
   async setExpectInstance(expect) {
     expectInstance = expect;
   },
@@ -87,8 +95,7 @@ module.exports = {
     return true;
   },
   async assignWindows() {
-    const metamaskExtensionData = (await module.exports.getExtensionsData())
-      .metamask;
+    const metamaskExtensionId = await module.exports.metamaskExtensionId();
 
     let pages = await browser.contexts()[0].pages();
     for (const page of pages) {
@@ -97,21 +104,21 @@ module.exports = {
       } else if (
         page
           .url()
-          .includes(`chrome-extension://${metamaskExtensionData.id}/home.html`)
+          .includes(`chrome-extension://${metamaskExtensionId}/home.html`)
       ) {
         metamaskWindow = page;
       } else if (
         page
           .url()
           .includes(
-            `chrome-extension://${metamaskExtensionData.id}/notification.html`,
+            `chrome-extension://${metamaskExtensionId}/notification.html`,
           )
       ) {
         metamaskNotificationWindow = page;
       } else if (
         page
           .url()
-          .includes(`chrome-extension://${metamaskExtensionData.id}/popup.html`)
+          .includes(`chrome-extension://${metamaskExtensionId}/popup.html`)
       ) {
         metamaskPopupWindow = page;
       }
@@ -161,8 +168,7 @@ module.exports = {
     return true;
   },
   async switchToMetamaskNotification() {
-    const metamaskExtensionData = (await module.exports.getExtensionsData())
-      .metamask;
+    const metamaskExtensionId = await module.exports.metamaskExtensionId();
 
     let pages = await browser.contexts()[0].pages();
     for (const page of pages) {
@@ -170,7 +176,7 @@ module.exports = {
         page
           .url()
           .includes(
-            `chrome-extension://${metamaskExtensionData.id}/notification.html`,
+            `chrome-extension://${metamaskExtensionId}/notification.html`,
           )
       ) {
         metamaskNotificationWindow = page;
@@ -337,15 +343,14 @@ module.exports = {
     }
   },
   async waitUntilStable(page) {
-    const metamaskExtensionData = (await module.exports.getExtensionsData())
-      .metamask;
+    const metamaskExtensionId = await module.exports.metamaskExtensionId();
 
     if (
       page &&
       page
         .url()
         .includes(
-          `chrome-extension://${metamaskExtensionData.id}/notification.html`,
+          `chrome-extension://${metamaskExtensionId}/notification.html`,
         )
     ) {
       await page.waitForLoadState('load');


### PR DESCRIPTION
## Motivation and context

In localized Chrome version extension would be reported as `Identifier: ID` instead of just an `ID`. This fix handles that behavior

## Does it fix any issue?

setupMetamask would hang as there will be no `metamaskPage` in commands/playwright

## Other useful info

Tested with Chrome 116 and 118 (arm)

## Quality checklist

- [x] I have performed a self-review of my code.
