### PR TITLE
Feature/revoke permission to all

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1374,6 +1374,24 @@ const metamask = {
     );
     return true;
   },
+  async confirmRevokePermissionToAll() {
+    const notificationPage = await playwright.switchToMetamaskNotification();
+    await playwright.waitAndClick(
+      notificationPageElements.allowToSpendButton,
+      notificationPage,
+      { waitForEvent: 'close' },
+    );
+    return true;
+  },
+  async rejectRevokePermissionToAll() {
+    const notificationPage = await playwright.switchToMetamaskNotification();
+    await playwright.waitAndClick(
+      notificationPageElements.rejectToSpendButton,
+      notificationPage,
+      { waitForEvent: 'close' },
+    );
+    return true;
+  },
   async allowToAddNetwork({ waitForEvent } = {}) {
     const notificationPage = await playwright.switchToMetamaskNotification();
     if (waitForEvent) {

--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1348,7 +1348,7 @@ const metamask = {
     );
     return true;
   },
-  async confirmPermisionToApproveAll() {
+  async confirmPermissionToApproveAll() {
     const notificationPage = await playwright.switchToMetamaskNotification();
     await playwright.waitAndClick(
       notificationPageElements.allowToSpendButton,
@@ -1361,7 +1361,7 @@ const metamask = {
     );
     return true;
   },
-  async rejectPermisionToApproveAll() {
+  async rejectPermissionToApproveAll() {
     const notificationPage = await playwright.switchToMetamaskNotification();
     await playwright.waitAndClick(
       notificationPageElements.allowToSpendButton,

--- a/docs/synpress-commands.md
+++ b/docs/synpress-commands.md
@@ -5,7 +5,7 @@
 Connect playwright with Cypress instance.
 
 ```ts
-initPlaywright(): Chainable<Subject>;
+initPlaywright(): Chainable<boolean>;
 ```
 
 #### `cy.assignWindows()`
@@ -13,7 +13,7 @@ initPlaywright(): Chainable<Subject>;
 Assign currently open tabs with playwright.
 
 ```ts
-assignWindows(): Chainable<Subject>;
+assignWindows(): Chainable<boolean>;
 ```
 
 #### `cy.assignActiveTabName()`
@@ -21,7 +21,7 @@ assignWindows(): Chainable<Subject>;
 Assigns currently active tab.
 
 ```ts
-assignActiveTabName(): Chainable<Subject>;
+assignActiveTabName(tabName: string): Chainable<boolean>;
 ```
 
 #### `cy.isMetamaskWindowActive()`
@@ -29,7 +29,7 @@ assignActiveTabName(): Chainable<Subject>;
 Checks if current active tab is metamask.
 
 ```ts
-isMetamaskWindowActive(): Chainable<Subject>;
+isMetamaskWindowActive(): Chainable<boolean>;
 ```
 
 #### `cy.isCypressWindowActive()`
@@ -37,7 +37,7 @@ isMetamaskWindowActive(): Chainable<Subject>;
 Checks if current active tab is cypress.
 
 ```ts
-isCypressWindowActive(): Chainable<Subject>;
+isCypressWindowActive(): Chainable<boolean>;
 ```
 
 #### `cy.switchToCypressWindow()`
@@ -45,7 +45,7 @@ isCypressWindowActive(): Chainable<Subject>;
 Switch to Cypress window.
 
 ```ts
-switchToCypressWindow(): Chainable<Subject>;
+switchToCypressWindow(): Chainable<boolean>;
 ```
 
 #### `cy.switchToMetamaskWindow()`
@@ -53,7 +53,7 @@ switchToCypressWindow(): Chainable<Subject>;
 Switch to metamask window.
 
 ```ts
-switchToMetamaskWindow(): Chainable<Subject>;
+switchToMetamaskWindow(): Chainable<boolean>;
 ```
 
 #### `cy.switchToMetamaskNotification()`
@@ -61,7 +61,7 @@ switchToMetamaskWindow(): Chainable<Subject>;
 Switch to metamask notification window.
 
 ```ts
-switchToMetamaskNotification(): Chainable<Subject>;
+switchToMetamaskNotification(): Chainable<boolean>;
 ```
 
 #### `cy.getCurrentNetwork()`
@@ -77,15 +77,26 @@ getCurrentNetwork(): Chainable<Subject>;
 Add network in metamask (and also switch to the newly added network).
 
 ```ts
-addMetamaskNetwork(network: object): Chainable<Subject>;
+addMetamaskNetwork(
+  network:
+    | string
+    | {
+        networkName: string;
+        rpcUrl: string;
+        chainId: number;
+        symbol?: string;
+        blockExplorer?: string;
+        isTestnet: boolean;
+      },
+): Chainable<boolean>;
 ```
 
 #### `cy.changeMetamaskNetwork()`
 
-Change network in metamask.
+Change network in metamask (if network is not present, it will be added).
 
 ```ts
-changeMetamaskNetwork(network: string): Chainable<Subject>;
+changeMetamaskNetwork(network: string): Chainable<boolean>;
 ```
 
 #### `cy.importMetamaskAccount()`
@@ -93,7 +104,7 @@ changeMetamaskNetwork(network: string): Chainable<Subject>;
 Import new account in metamask using private key.
 
 ```ts
-importMetamaskAccount(privateKey: string): Chainable<Subject>;
+importMetamaskAccount(privateKey: string): Chainable<boolean>;
 ```
 
 #### `cy.createMetamaskAccount()`
@@ -101,7 +112,7 @@ importMetamaskAccount(privateKey: string): Chainable<Subject>;
 Create new account in metamask.
 
 ```ts
-createMetamaskAccount(accountName?: string): Chainable<Subject>;
+createMetamaskAccount(accountName?: string): Chainable<boolean>;
 ```
 
 #### `cy.renameMetamaskAccount()`
@@ -109,7 +120,7 @@ createMetamaskAccount(accountName?: string): Chainable<Subject>;
 Rename current account in metamask.
 
 ```ts
-createMetamaskAccount(newAccountName: string): Chainable<Subject>;
+renameMetamaskAccount(newAccountName: string): Chainable<boolean>;
 ```
 
 #### `cy.switchMetamaskAccount()`
@@ -119,7 +130,7 @@ Switch metamask account.
 ```ts
 switchMetamaskAccount(
   accountNameOrAccountNumber: string | number,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.getMetamaskWalletAddress()`
@@ -127,7 +138,7 @@ switchMetamaskAccount(
 Get current wallet address of metamask wallet.
 
 ```ts
-getMetamaskWalletAddress(): Chainable<Subject>;
+getMetamaskWalletAddress(): Chainable<string>;
 ```
 
 #### `cy.activateAdvancedGasControlInMetamask()`
@@ -138,7 +149,7 @@ while doing transactions in metamask.
 ```ts
 activateAdvancedGasControlInMetamask(
   skipSetup?: boolean,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.activateShowHexDataInMetamask()`
@@ -147,7 +158,7 @@ Activate ability (in metamask settings) to show hex data while doing transaction
 in metamask.
 
 ```ts
-activateShowHexDataInMetamask(skipSetup?: boolean): Chainable<Subject>;
+activateShowHexDataInMetamask(skipSetup?: boolean): Chainable<boolean>;
 ```
 
 #### `cy.activateTestnetConversionInMetamask()`
@@ -158,7 +169,7 @@ metamask.
 ```ts
 activateTestnetConversionInMetamask(
   skipSetup?: boolean,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.activateShowTestnetNetworksInMetamask()`
@@ -168,7 +179,7 @@ Activate ability (in metamask settings) to show testnet networks in metamask.
 ```ts
 activateShowTestnetNetworksInMetamask(
   skipSetup?: boolean,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.activateCustomNonceInMetamask()`
@@ -177,7 +188,7 @@ Activate ability (in metamask settings) to specify custom nonce while doing
 transactions in metamask.
 
 ```ts
-activateCustomNonceInMetamask(skipSetup?: boolean): Chainable<Subject>;
+activateCustomNonceInMetamask(skipSetup?: boolean): Chainable<boolean>;
 ```
 
 #### `cy.activateDismissBackupReminderInMetamask()`
@@ -188,7 +199,7 @@ reminder in metamask.
 ```ts
 activateDismissBackupReminderInMetamask(
   skipSetup?: boolean,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.activateEthSignRequestsInMetamask()`
@@ -196,7 +207,7 @@ activateDismissBackupReminderInMetamask(
 Activate eth sign requests in metamask settings.
 
 ```ts
-activateEthSignRequestsInMetamask(skipSetup?: boolean): Chainable<Subject>;
+activateEthSignRequestsInMetamask(skipSetup?: boolean): Chainable<boolean>;
 ```
 
 #### `cy.activateImprovedTokenAllowanceInMetamask()`
@@ -206,7 +217,7 @@ Activate improved token allowance in metamask settings (experimental).
 ```ts
 activateImprovedTokenAllowanceInMetamask(
   skipSetup?: boolean,
-): Chainable<Subject>;
+): Chainable<boolean>;
 ```
 
 #### `cy.resetMetamaskAccount()`
@@ -214,7 +225,7 @@ activateImprovedTokenAllowanceInMetamask(
 Reset metamask account state in settings.
 
 ```ts
-resetMetamaskAccount(): Chainable<Subject>;
+resetMetamaskAccount(): Chainable<boolean>;
 ```
 
 #### `cy.disconnectMetamaskWalletFromDapp()`
@@ -222,7 +233,7 @@ resetMetamaskAccount(): Chainable<Subject>;
 Disconnects metamask wallet from last connected dapp.
 
 ```ts
-disconnectMetamaskWalletFromDapp(): Chainable<Subject>;
+disconnectMetamaskWalletFromDapp(): Chainable<boolean>;
 ```
 
 #### `cy.disconnectMetamaskWalletFromAllDapps()`
@@ -230,7 +241,7 @@ disconnectMetamaskWalletFromDapp(): Chainable<Subject>;
 Disconnects metamask wallet from all connected dapps.
 
 ```ts
-disconnectMetamaskWalletFromAllDapps(): Chainable<Subject>;
+disconnectMetamaskWalletFromAllDapps(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskSignatureRequest()`
@@ -238,7 +249,7 @@ disconnectMetamaskWalletFromAllDapps(): Chainable<Subject>;
 Confirm metamask permission to sign message.
 
 ```ts
-confirmMetamaskSignatureRequest(): Chainable<Subject>;
+confirmMetamaskSignatureRequest(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskDataSignatureRequest()`
@@ -246,7 +257,7 @@ confirmMetamaskSignatureRequest(): Chainable<Subject>;
 Confirm metamask permission to sign Data message.
 
 ```ts
-confirmMetamaskDataSignatureRequest(): Chainable<Subject>;
+confirmMetamaskDataSignatureRequest(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskSignatureRequest()`
@@ -254,7 +265,7 @@ confirmMetamaskDataSignatureRequest(): Chainable<Subject>;
 Reject metamask permission to sign message.
 
 ```ts
-rejectMetamaskSignatureRequest(): Chainable<Subject>;
+rejectMetamaskSignatureRequest(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskEncryptionPublicKeyRequest()`
@@ -262,7 +273,7 @@ rejectMetamaskSignatureRequest(): Chainable<Subject>;
 Confirm metamask request for public encryption key.
 
 ```ts
-confirmMetamaskEncryptionPublicKeyRequest(): Chainable<Subject>;
+confirmMetamaskEncryptionPublicKeyRequest(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskEncryptionPublicKeyRequest()`
@@ -270,7 +281,7 @@ confirmMetamaskEncryptionPublicKeyRequest(): Chainable<Subject>;
 Reject metamask request for public encryption key.
 
 ```ts
-rejectMetamaskEncryptionPublicKeyRequest(): Chainable<Subject>;
+rejectMetamaskEncryptionPublicKeyRequest(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskDecryptionRequest()`
@@ -278,7 +289,7 @@ rejectMetamaskEncryptionPublicKeyRequest(): Chainable<Subject>;
 Confirm metamask request to decrypt message with private key.
 
 ```ts
-confirmMetamaskDecryptionRequest(): Chainable<Subject>;
+confirmMetamaskDecryptionRequest(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskDecryptionRequest()`
@@ -286,7 +297,7 @@ confirmMetamaskDecryptionRequest(): Chainable<Subject>;
 Reject metamask request to decrypt message with private key.
 
 ```ts
-rejectMetamaskDecryptionRequest(): Chainable<Subject>;
+rejectMetamaskDecryptionRequest(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskDataSignatureRequest()`
@@ -294,7 +305,7 @@ rejectMetamaskDecryptionRequest(): Chainable<Subject>;
 Reject metamask permission to sign Data message.
 
 ```ts
-rejectMetamaskDataSignatureRequest(): Chainable<Subject>;
+rejectMetamaskDataSignatureRequest(): Chainable<boolean>;
 ```
 
 #### `cy.importMetamaskToken()`
@@ -302,7 +313,14 @@ rejectMetamaskDataSignatureRequest(): Chainable<Subject>;
 Add custom token to metamask.
 
 ```ts
-importMetamaskToken(tokenConfig?: object | string): Chainable<Subject>;
+importMetamaskToken(
+  tokenConfig?:
+    | {
+        address: string;
+        symbol: string;
+      }
+    | string,
+): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskAddToken()`
@@ -310,7 +328,7 @@ importMetamaskToken(tokenConfig?: object | string): Chainable<Subject>;
 Confirm metamask request to add token.
 
 ```ts
-confirmMetamaskAddToken(): Chainable<Subject>;
+confirmMetamaskAddToken(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskAddToken()`
@@ -318,7 +336,7 @@ confirmMetamaskAddToken(): Chainable<Subject>;
 Reject metamask request to add token.
 
 ```ts
-rejectMetamaskAddToken(): Chainable<Subject>;
+rejectMetamaskAddToken(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskPermissionToSpend()`
@@ -326,7 +344,7 @@ rejectMetamaskAddToken(): Chainable<Subject>;
 Confirm metamask permission to spend asset.
 
 ```ts
-confirmMetamaskPermissionToSpend(spendLimit?: string): Chainable<Subject>;
+confirmMetamaskPermissionToSpend(spendLimit?: string): Chainable<string>;
 ```
 
 #### `cy.confirmMetamaskPermissionToApproveAll()`
@@ -334,7 +352,7 @@ confirmMetamaskPermissionToSpend(spendLimit?: string): Chainable<Subject>;
 Confirm metamask permission to access all elements (example: collectibles).
 
 ```ts
-confirmMetamaskPermissionToApproveAll(): Chainable<Subject>;
+confirmMetamaskPermissionToApproveAll(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskPermissionToApproveAll()`
@@ -342,7 +360,25 @@ confirmMetamaskPermissionToApproveAll(): Chainable<Subject>;
 Reject metamask permission to access all elements (example: collectibles).
 
 ```ts
-rejectMetamaskPermissionToApproveAll(): Chainable<Subject>;
+rejectMetamaskPermissionToApproveAll(): Chainable<boolean>;
+```
+
+#### `cy.confirmMetamaskRevokePermissionToAll()`
+
+Confirm metamask revoking permission to access all elements (example:
+collectibles).
+
+```ts
+confirmMetamaskRevokePermissionToAll(): Chainable<boolean>;
+```
+
+#### `cy.rejectMetamaskRevokePermissionToAll()`
+
+Reject metamask revoking permission to access all elements (example:
+collectibles).
+
+```ts
+rejectMetamaskRevokePermissionToAll(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskPermissionToSpend()`
@@ -350,7 +386,7 @@ rejectMetamaskPermissionToApproveAll(): Chainable<Subject>;
 Reject metamask permission to spend asset.
 
 ```ts
-rejectMetamaskPermissionToSpend(): Chainable<Subject>;
+rejectMetamaskPermissionToSpend(): Chainable<boolean>;
 ```
 
 #### `cy.acceptMetamaskAccess()`
@@ -362,7 +398,15 @@ acceptMetamaskAccess(options?: {
   allAccounts?: boolean;
   confirmSignatureRequest?: boolean;
   confirmDataSignatureRequest?: boolean;
-}): Chainable<Subject>;
+}): Chainable<boolean>;
+```
+
+#### `cy.rejectMetamaskAccess()`
+
+Reject metamask access request.
+
+```ts
+rejectMetamaskAccess(): Chainable<boolean>;
 ```
 
 #### `cy.confirmMetamaskTransaction()`
@@ -370,7 +414,22 @@ acceptMetamaskAccess(options?: {
 Confirm metamask transaction (auto-detects eip-1559 and legacy transactions).
 
 ```ts
-confirmMetamaskTransaction(gasConfig?: object | string): Chainable<Subject>;
+confirmMetamaskTransaction(
+  gasConfig?:
+    | {
+        gasLimit?: number;
+        baseFee?: number;
+        priorityFee?: number;
+      }
+    | {
+        gasLimit?: number;
+        gasPrice?: number;
+      }
+    | 'low'
+    | 'market'
+    | 'aggressive'
+    | 'site',
+): Chainable<Subject>;
 ```
 
 #### `cy.confirmMetamaskTransactionAndWaitForMining()`
@@ -379,7 +438,22 @@ Confirm metamask transaction (auto-detects eip-1559 and legacy transactions) and
 wait for ALL pending transactions to be mined.
 
 ```ts
-confirmMetamaskTransactionAndWaitForMining(gasConfig?: object | string): Chainable<Subject>;
+confirmMetamaskTransactionAndWaitForMining(
+  gasConfig?:
+    | {
+        gasLimit?: number;
+        baseFee?: number;
+        priorityFee?: number;
+      }
+    | {
+        gasLimit?: number;
+        gasPrice?: number;
+      }
+    | 'low'
+    | 'market'
+    | 'aggressive'
+    | 'site',
+): Chainable<Subject>;
 ```
 
 #### `cy.rejectMetamaskTransaction()`
@@ -387,7 +461,7 @@ confirmMetamaskTransactionAndWaitForMining(gasConfig?: object | string): Chainab
 Reject metamask transaction.
 
 ```ts
-rejectMetamaskTransaction(): Chainable<Subject>;
+rejectMetamaskTransaction(): Chainable<boolean>;
 ```
 
 #### `cy.openMetamaskTransactionDetails()`
@@ -401,10 +475,10 @@ openMetamaskTransactionDetails(txIndex: number): Chainable<Subject>;
 
 #### `cy.closeMetamaskTransactionDetailsPopup()`
 
-Close currently open transaction details popup.
+Close metamask transaction details popup.
 
 ```ts
-closeMetamaskTransactionDetailsPopup(): Chainable<Subject>;
+closeMetamaskTransactionDetailsPopup(): Chainable<boolean>;
 ```
 
 #### `cy.allowMetamaskToAddNetwork()`
@@ -412,7 +486,7 @@ closeMetamaskTransactionDetailsPopup(): Chainable<Subject>;
 Allow site to add new network in metamask.
 
 ```ts
-allowMetamaskToAddNetwork(waitForEvent?: string): Chainable<Subject>;
+allowMetamaskToAddNetwork(waitForEvent?: string): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskToAddNetwork()`
@@ -420,7 +494,7 @@ allowMetamaskToAddNetwork(waitForEvent?: string): Chainable<Subject>;
 Reject site to add new network in metamask.
 
 ```ts
-rejectMetamaskToAddNetwork(): Chainable<Subject>;
+rejectMetamaskToAddNetwork(): Chainable<boolean>;
 ```
 
 #### `cy.allowMetamaskToSwitchNetwork()`
@@ -428,7 +502,7 @@ rejectMetamaskToAddNetwork(): Chainable<Subject>;
 Allow site to switch network in metamask.
 
 ```ts
-allowMetamaskToSwitchNetwork(): Chainable<Subject>;
+allowMetamaskToSwitchNetwork(): Chainable<boolean>;
 ```
 
 #### `cy.rejectMetamaskToSwitchNetwork()`
@@ -436,7 +510,7 @@ allowMetamaskToSwitchNetwork(): Chainable<Subject>;
 Reject site to switch network in metamask.
 
 ```ts
-rejectMetamaskToSwitchNetwork(): Chainable<Subject>;
+rejectMetamaskToSwitchNetwork(): Chainable<boolean>;
 ```
 
 #### `cy.allowMetamaskToAddAndSwitchNetwork()`
@@ -444,7 +518,7 @@ rejectMetamaskToSwitchNetwork(): Chainable<Subject>;
 Allow site to add new network in metamask and switch to it.
 
 ```ts
-allowMetamaskToAddAndSwitchNetwork(): Chainable<Subject>;
+allowMetamaskToAddAndSwitchNetwork(): Chainable<boolean>;
 ```
 
 #### `cy.unlockMetamask()`
@@ -452,7 +526,7 @@ allowMetamaskToAddAndSwitchNetwork(): Chainable<Subject>;
 Unlock metamask.
 
 ```ts
-unlockMetamask(password: string): Chainable<Subject>;
+unlockMetamask(password: string): Chainable<boolean>;
 ```
 
 #### `cy.fetchMetamaskWalletAddress()`
@@ -460,7 +534,7 @@ unlockMetamask(password: string): Chainable<Subject>;
 Fetches previous metamask wallet address.
 
 ```ts
-fetchMetamaskWalletAddress(): Chainable<Subject>;
+fetchMetamaskWalletAddress(): Chainable<boolean>;
 ```
 
 #### `cy.setupMetamask()`
@@ -470,7 +544,16 @@ Run the flow for metamask setup.
 ```ts
 setupMetamask(
   secretWordsOrPrivateKey?: string,
-  network?: string | object,
+  network?:
+    | string
+    | {
+        networkName: string;
+        rpcUrl: string;
+        chainId: number;
+        symbol?: string;
+        blockExplorer?: string;
+        isTestnet: boolean;
+      },
   password?: string,
   enableAdvancedSettings?: boolean,
   enableExperimentalSettings?: boolean,
@@ -490,7 +573,7 @@ etherscanGetTransactionStatus(txid: string): Chainable<Subject>;
 Wait until transaction is success using Etherscan API.
 
 ```ts
-etherscanWaitForTxSuccess(txid: string): Chainable<Subject>;
+etherscanWaitForTxSuccess(txid: string): Chainable<boolean>;
 ```
 
 #### `cy.waitForResources()`

--- a/docs/synpress-commands.md
+++ b/docs/synpress-commands.md
@@ -132,7 +132,8 @@ getMetamaskWalletAddress(): Chainable<Subject>;
 
 #### `cy.activateAdvancedGasControlInMetamask()`
 
-Activate ability (in metamask settings) to specify custom gas price and limit while doing transactions in metamask.
+Activate ability (in metamask settings) to specify custom gas price and limit
+while doing transactions in metamask.
 
 ```ts
 activateAdvancedGasControlInMetamask(
@@ -142,7 +143,8 @@ activateAdvancedGasControlInMetamask(
 
 #### `cy.activateShowHexDataInMetamask()`
 
-Activate ability (in metamask settings) to show hex data while doing transaction in metamask.
+Activate ability (in metamask settings) to show hex data while doing transaction
+in metamask.
 
 ```ts
 activateShowHexDataInMetamask(skipSetup?: boolean): Chainable<Subject>;
@@ -150,7 +152,8 @@ activateShowHexDataInMetamask(skipSetup?: boolean): Chainable<Subject>;
 
 #### `cy.activateTestnetConversionInMetamask()`
 
-Activate ability (in metamask settings) to show fiat conversions on testnets in metamask.
+Activate ability (in metamask settings) to show fiat conversions on testnets in
+metamask.
 
 ```ts
 activateTestnetConversionInMetamask(
@@ -170,7 +173,8 @@ activateShowTestnetNetworksInMetamask(
 
 #### `cy.activateCustomNonceInMetamask()`
 
-Activate ability (in metamask settings) to specify custom nonce while doing transactions in metamask.
+Activate ability (in metamask settings) to specify custom nonce while doing
+transactions in metamask.
 
 ```ts
 activateCustomNonceInMetamask(skipSetup?: boolean): Chainable<Subject>;
@@ -178,7 +182,8 @@ activateCustomNonceInMetamask(skipSetup?: boolean): Chainable<Subject>;
 
 #### `cy.activateDismissBackupReminderInMetamask()`
 
-Activate ability (in metamask settings) to dismiss secret recovery phrase reminder in metamask.
+Activate ability (in metamask settings) to dismiss secret recovery phrase
+reminder in metamask.
 
 ```ts
 activateDismissBackupReminderInMetamask(
@@ -324,20 +329,20 @@ Confirm metamask permission to spend asset.
 confirmMetamaskPermissionToSpend(spendLimit?: string): Chainable<Subject>;
 ```
 
-#### `cy.confirmMetamaskPermisionToApproveAll()`
+#### `cy.confirmMetamaskPermissionToApproveAll()`
 
 Confirm metamask permission to access all elements (example: collectibles).
 
 ```ts
-confirmMetamaskPermisionToApproveAll(): Chainable<Subject>;
+confirmMetamaskPermissionToApproveAll(): Chainable<Subject>;
 ```
 
-#### `cy.rejectMetamaskPermisionToApproveAll()`
+#### `cy.rejectMetamaskPermissionToApproveAll()`
 
 Reject metamask permission to access all elements (example: collectibles).
 
 ```ts
-rejectMetamaskPermisionToApproveAll(): Chainable<Subject>;
+rejectMetamaskPermissionToApproveAll(): Chainable<Subject>;
 ```
 
 #### `cy.rejectMetamaskPermissionToSpend()`
@@ -370,7 +375,8 @@ confirmMetamaskTransaction(gasConfig?: object | string): Chainable<Subject>;
 
 #### `cy.confirmMetamaskTransactionAndWaitForMining()`
 
-Confirm metamask transaction (auto-detects eip-1559 and legacy transactions) and wait for ALL pending transactions to be mined.
+Confirm metamask transaction (auto-detects eip-1559 and legacy transactions) and
+wait for ALL pending transactions to be mined.
 
 ```ts
 confirmMetamaskTransactionAndWaitForMining(gasConfig?: object | string): Chainable<Subject>;
@@ -386,7 +392,8 @@ rejectMetamaskTransaction(): Chainable<Subject>;
 
 #### `cy.openMetamaskTransactionDetails()`
 
-Open metamask transaction details based on the index of the transaction in the list on the activity tab.
+Open metamask transaction details based on the index of the transaction in the
+list on the activity tab.
 
 ```ts
 openMetamaskTransactionDetails(txIndex: number): Chainable<Subject>;
@@ -514,4 +521,3 @@ isWithinViewport(
   viewportHeight: number,
 ): Chainable<Subject>;
 ```
-

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -103,8 +103,9 @@ module.exports = (on, config) => {
     rejectMetamaskAddToken: metamask.rejectAddToken,
     confirmMetamaskPermissionToSpend: metamask.confirmPermissionToSpend,
     rejectMetamaskPermissionToSpend: metamask.rejectPermissionToSpend,
-    confirmMetamaskPermisionToApproveAll: metamask.confirmPermisionToApproveAll,
-    rejectMetamaskPermisionToApproveAll: metamask.rejectPermisionToApproveAll,
+    confirmMetamaskPermissionToApproveAll:
+      metamask.confirmPermissionToApproveAll,
+    rejectMetamaskPermissionToApproveAll: metamask.rejectPermissionToApproveAll,
     acceptMetamaskAccess: metamask.acceptAccess,
     rejectMetamaskAccess: metamask.rejectAccess,
     confirmMetamaskTransaction: metamask.confirmTransaction,

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -106,6 +106,8 @@ module.exports = (on, config) => {
     confirmMetamaskPermissionToApproveAll:
       metamask.confirmPermissionToApproveAll,
     rejectMetamaskPermissionToApproveAll: metamask.rejectPermissionToApproveAll,
+    confirmMetamaskRevokePermissionToAll: metamask.confirmRevokePermissionToAll,
+    rejectMetamaskRevokePermissionToAll: metamask.rejectRevokePermissionToAll,
     acceptMetamaskAccess: metamask.acceptAccess,
     rejectMetamaskAccess: metamask.rejectAccess,
     confirmMetamaskTransaction: metamask.confirmTransaction,

--- a/support/commands.js
+++ b/support/commands.js
@@ -215,12 +215,12 @@ Cypress.Commands.add('closeMetamaskTransactionDetailsPopup', () => {
   return cy.task('closeMetamaskTransactionDetailsPopup');
 });
 
-Cypress.Commands.add('rejectMetamaskPermisionToApproveAll', () => {
-  return cy.task('rejectMetamaskPermisionToApproveAll');
+Cypress.Commands.add('rejectMetamaskPermissionToApproveAll', () => {
+  return cy.task('rejectMetamaskPermissionToApproveAll');
 });
 
-Cypress.Commands.add('confirmMetamaskPermisionToApproveAll', () => {
-  return cy.task('confirmMetamaskPermisionToApproveAll');
+Cypress.Commands.add('confirmMetamaskPermissionToApproveAll', () => {
+  return cy.task('confirmMetamaskPermissionToApproveAll');
 });
 
 Cypress.Commands.add('allowMetamaskToAddNetwork', waitForEvent => {

--- a/support/commands.js
+++ b/support/commands.js
@@ -223,6 +223,14 @@ Cypress.Commands.add('confirmMetamaskPermissionToApproveAll', () => {
   return cy.task('confirmMetamaskPermissionToApproveAll');
 });
 
+Cypress.Commands.add('confirmMetamaskRevokePermissionToAll', () => {
+  return cy.task('confirmMetamaskRevokePermissionToAll');
+});
+
+Cypress.Commands.add('rejectMetamaskRevokePermissionToAll', () => {
+  return cy.task('rejectMetamaskRevokePermissionToAll');
+});
+
 Cypress.Commands.add('allowMetamaskToAddNetwork', waitForEvent => {
   return cy.task('allowMetamaskToAddNetwork', { waitForEvent });
 });

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -278,15 +278,15 @@ declare namespace Cypress {
     /**
      * Confirm metamask permission to access all elements (example: collectibles)
      * @example
-     * cy.confirmMetamaskPermisionToApproveAll()
+     * cy.confirmMetamaskPermissionToApproveAll()
      */
-    confirmMetamaskPermisionToApproveAll(): Chainable<boolean>;
+    confirmMetamaskPermissionToApproveAll(): Chainable<boolean>;
     /**
      * Reject metamask permission to access all elements (example: collectibles)
      * @example
-     * cy.rejectMetamaskPermisionToApproveAll()
+     * cy.rejectMetamaskPermissionToApproveAll()
      */
-    rejectMetamaskPermisionToApproveAll(): Chainable<boolean>;
+    rejectMetamaskPermissionToApproveAll(): Chainable<boolean>;
     /**
      * Reject metamask permission to spend asset
      * @example
@@ -345,14 +345,14 @@ declare namespace Cypress {
     confirmMetamaskTransactionAndWaitForMining(
       gasConfig?:
         | {
-        gasLimit?: number;
-        baseFee?: number;
-        priorityFee?: number;
-      }
+            gasLimit?: number;
+            baseFee?: number;
+            priorityFee?: number;
+          }
         | {
-        gasLimit?: number;
-        gasPrice?: number;
-      }
+            gasLimit?: number;
+            gasPrice?: number;
+          }
         | 'low'
         | 'market'
         | 'aggressive'

--- a/support/index.d.ts
+++ b/support/index.d.ts
@@ -288,6 +288,18 @@ declare namespace Cypress {
      */
     rejectMetamaskPermissionToApproveAll(): Chainable<boolean>;
     /**
+     * Confirm metamask revoking permission to access all elements (example: collectibles)
+     * @example
+     * cy.confirmMetamaskRevokePermissionToAll()
+     */
+    confirmMetamaskRevokePermissionToAll(): Chainable<boolean>;
+    /**
+     * Reject metamask revoking permission to access all elements (example: collectibles)
+     * @example
+     * cy.rejectMetamaskRevokePermissionToAll()
+     */
+    rejectMetamaskRevokePermissionToAll(): Chainable<boolean>;
+    /**
      * Reject metamask permission to spend asset
      * @example
      * cy.rejectMetamaskPermissionToSpend()

--- a/tests/e2e/specs/metamask-spec.js
+++ b/tests/e2e/specs/metamask-spec.js
@@ -144,6 +144,18 @@ describe('Metamask', () => {
         expect(confirmed).to.be.true;
       });
     });
+    it(`rejectMetamaskRevokePermissionToAll should reject revoking permission to all NFTs`, () => {
+      cy.get('#revokeButton').click();
+      cy.rejectMetamaskRevokePermissionToAll().then(confirmed => {
+        expect(confirmed).to.be.true;
+      });
+    });
+    it(`confirmMetamaskRevokePermissionToAll should confirm revoking permission to all NFTs`, () => {
+      cy.get('#revokeButton').click();
+      cy.confirmMetamaskRevokePermissionToAll().then(confirmed => {
+        expect(confirmed).to.be.true;
+      });
+    });
     it(`importMetamaskAccount should import new account using private key`, () => {
       cy.importMetamaskAccount(
         '0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6',

--- a/tests/e2e/specs/metamask-spec.js
+++ b/tests/e2e/specs/metamask-spec.js
@@ -128,19 +128,19 @@ describe('Metamask', () => {
         cy.changeMetamaskNetwork('sepolia');
       }
     });
-    it(`rejectMetamaskPermisionToApproveAll should reject permission to approve all NFTs upon warning`, () => {
+    it(`rejectMetamaskPermissionToApproveAll should reject permission to approve all NFTs upon warning`, () => {
       cy.get('#deployNFTsButton').click();
       cy.confirmMetamaskTransaction();
       cy.get('#mintButton').click();
       cy.confirmMetamaskTransaction();
       cy.get('#setApprovalForAllButton').click();
-      cy.rejectMetamaskPermisionToApproveAll().then(rejected => {
+      cy.rejectMetamaskPermissionToApproveAll().then(rejected => {
         expect(rejected).to.be.true;
       });
     });
-    it(`confirmMetamaskPermisionToApproveAll should confirm permission to approve all NFTs`, () => {
+    it(`confirmMetamaskPermissionToApproveAll should confirm permission to approve all NFTs`, () => {
       cy.get('#setApprovalForAllButton').click();
-      cy.confirmMetamaskPermisionToApproveAll().then(confirmed => {
+      cy.confirmMetamaskPermissionToApproveAll().then(confirmed => {
         expect(confirmed).to.be.true;
       });
     });


### PR DESCRIPTION
## Motivation and context

Synpress seemed to be missing handlers for revoking access to NFT collections - follow up actions for `confirmPermissionToApproveAll`. This PR aims at adding them

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.
