### PR TITLE
:sparkles: feat: Watch token using EIP747

### DIFF
--- a/wallets/metamask/test/e2e/metamask/addNewToken.spec.ts
+++ b/wallets/metamask/test/e2e/metamask/addNewToken.spec.ts
@@ -1,6 +1,5 @@
 import Selectors from '../../../src/pages/HomePage/selectors'
 import { testWithMetaMask } from '../testWithMetaMask'
-
 const test = testWithMetaMask
 
 const { expect } = test
@@ -13,4 +12,17 @@ test('should add new token to MetaMask', async ({ page, metamask, metamaskPage, 
   await metamask.addNewToken()
 
   await expect(metamaskPage.locator(Selectors.portfolio.singleToken).nth(1)).toContainText('TST')
+})
+
+test('should add new token using EIP747', async ({ page, metamask, deployToken }) => {
+  await deployToken()
+
+  await page.locator('#eip747ContractAddress').fill('0x5FbDB2315678afecb367f032d93F642f64180aa3')
+  await page.locator('#eip747Symbol').fill('TST')
+  await page.locator('#eip747Decimals').fill('4')
+
+  await page.locator('#eip747WatchButton').click()
+  await metamask.addNewToken()
+
+  await expect(page.locator('#eip747Status')).toHaveText('NFT added successfully')
 })


### PR DESCRIPTION
## Motivation and context

Watch token using EIP747

## Does it fix any issue?

https://linear.app/synpress/issue/SYN-65/watch-token-using-eip747

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**


---

<details open="true"><summary>Generated summary</summary>

> # TL;DR
> This pull request adds a new end-to-end test for adding a new token using EIP747 in the MetaMask wallet.
> 
> # What changed
> A new test case has been added to the `addNewToken.spec.ts` file. This test case simulates the process of adding a new token using EIP747. It fills in the contract address, symbol, and decimals for the new token, clicks the watch button, and then checks that the token has been added successfully.
> 
> # How to test
> To test this change, you can run the end-to-end tests for the MetaMask wallet. The new test case should be included in the test suite. Ensure that the test passes and that it accurately represents the process of adding a new token using EIP747.
> 
> # Why make this change
> This change is necessary to ensure that the functionality for adding a new token using EIP747 is working as expected in the MetaMask wallet. By adding this test case, we can catch any potential issues or regressions with this feature in the future.
</details>