### PR TITLE
add delay on initial setup - import account

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -1509,6 +1509,7 @@ const metamask = {
       } else {
         // private key
         await module.exports.createWallet(password);
+        await sleep(1000);
         await module.exports.importAccount(secretWordsOrPrivateKey);
       }
 


### PR DESCRIPTION
## Motivation and context

I found a weird bug when looping the same test 10 or 20 times
This only happens if use the private key metamask, not the seed phrase

my temporary solution is to add delay of 1 sec

---

### Root Cause Issue
synpress test failed because could not find the import button

https://github.com/Synthetixio/synpress/blob/9466f3ebd5df3f8918de28208b583840533e37b0/commands/metamask.js#L359

the video url:

https://www.loom.com/share/d26f8fd726394c6b95f10f5122540015

##

## Does it fix any issue?

yes, it will reduce the bugs
