### PR TITLE
fix: fixed metamask commands to support v11.15.5 

### DIFF
--- a/commands/metamask.js
+++ b/commands/metamask.js
@@ -642,13 +642,6 @@ const metamask = {
     await switchToCypressIfNotActive();
     return true;
   },
-  async activateAdvancedGasControl(skipSetup) {
-    return await activateAdvancedSetting(
-      advancedPageElements.advancedGasControlToggleOn,
-      advancedPageElements.advancedGasControlToggleOff,
-      skipSetup,
-    );
-  },
   async activateShowHexData(skipSetup) {
     return await activateAdvancedSetting(
       advancedPageElements.showHexDataToggleOn,
@@ -864,11 +857,13 @@ const metamask = {
         .locator(notificationPageElements.customSpendingLimitInput)
         .count()) > 0
     ) {
-      await playwright.waitAndSetValue(
-        spendLimit,
-        notificationPageElements.customSpendingLimitInput,
-        notificationPage,
-      );
+      if (spendLimit) {
+        await playwright.waitAndSetValue(
+          spendLimit,
+          notificationPageElements.customSpendingLimitInput,
+          notificationPage,
+        );
+      }
       await playwright.waitAndClick(
         notificationPageElements.allowToSpendButton,
         notificationPage,
@@ -1128,7 +1123,7 @@ const metamask = {
           confirmPageElements.recipientButton,
           notificationPage,
         );
-        txData.recipientPublicAddress = await playwright.waitAndGetValue(
+        txData.recipientPublicAddress = await playwright.waitAndGetInputValue(
           recipientPopupElements.recipientPublicAddress,
           notificationPage,
         );
@@ -1503,6 +1498,10 @@ const metamask = {
         .locator(onboardingWelcomePageElements.onboardingWelcomePage)
         .count()) > 0
     ) {
+      // check terms checkbox
+      await playwright.waitAndClick(
+        onboardingWelcomePageElements.onboardingTermsCheckbox,
+      );
       if (secretWordsOrPrivateKey.includes(' ')) {
         // secret words
         await module.exports.importWallet(secretWordsOrPrivateKey, password);
@@ -1512,6 +1511,10 @@ const metamask = {
         await module.exports.importAccount(secretWordsOrPrivateKey);
       }
 
+      // Enhanced Transaction Protection
+      await playwright.waitAndClick(
+        mainPageElements.accountModal.primaryButton,
+      );
       await setupSettings(enableAdvancedSettings, enableExperimentalSettings);
 
       await module.exports.changeNetwork(network);
@@ -1601,7 +1604,6 @@ async function setupSettings(
 ) {
   await switchToMetamaskIfNotActive();
   await metamask.goToAdvancedSettings();
-  await metamask.activateAdvancedGasControl(true);
   await metamask.activateShowHexData(true);
   await metamask.activateShowTestnetNetworks(true);
   await metamask.activateCustomNonce(true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synthetixio/synpress",
-  "version": "3.7.2-beta.8",
+  "version": "3.7.2-beta.9",
   "packageManager": "pnpm@8.4.0",
   "description": "Synpress is e2e testing framework based around Cypress.io & playwright with included MetaMask support. Test your dapps with ease.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synthetixio/synpress",
   "version": "3.7.2-beta.9",
-  "packageManager": "pnpm@8.4.0",
+  "packageManager": "pnpm@9.0.4",
   "description": "Synpress is e2e testing framework based around Cypress.io & playwright with included MetaMask support. Test your dapps with ease.",
   "keywords": [
     "Synpress",

--- a/pages/metamask/first-time-flow-page.js
+++ b/pages/metamask/first-time-flow-page.js
@@ -9,12 +9,14 @@ module.exports.metametricsPageElements = {
 const app = '#app-content .app';
 const onboardingWelcomePage = `${onboardingFlow} [data-testid="onboarding-welcome"]`;
 const importWalletButton = `${onboardingWelcomePage} [data-testid="onboarding-import-wallet"]`;
+const onboardingTermsCheckbox = `${onboardingWelcomePage} [data-testid="onboarding-terms-checkbox"]`;
 const createWalletButton = `${onboardingWelcomePage} [data-testid="onboarding-create-wallet"]`;
 module.exports.onboardingWelcomePageElements = {
   app,
   onboardingWelcomePage,
   importWalletButton,
   createWalletButton,
+  onboardingTermsCheckbox,
 };
 
 const firstTimeFlowImportPage = `${onboardingFlow} [data-testid="import-srp"]`;

--- a/pages/metamask/main-page.js
+++ b/pages/metamask/main-page.js
@@ -1,12 +1,12 @@
-const networkSwitcherButtonSelector = '.network-display';
+const networkSwitcherButtonSelector = '[data-testid="network-display"]';
 const networkSwitcher = {
   button: networkSwitcherButtonSelector,
-  networkName: `${networkSwitcherButtonSelector} .typography`,
+  networkName: `${networkSwitcherButtonSelector} .mm-text--ellipsis`,
   dropdownMenu: '[data-testid="network-droppo"]',
-  dropdownMenuItem: `[data-testid="network-droppo"] .dropdown-menu-item`,
-  mainnetNetworkItem: `[data-testid="network-droppo"] [data-testid="mainnet-network-item"]`,
+  dropdownMenuItem: `.multichain-network-list-menu-content-wrapper__dialog`,
+  mainnetNetworkItem: `.multichain-network-list-menu-content-wrapper__dialog [data-testid="Ethereum Mainnet"]`,
   goerliNetworkItem: `[data-testid="network-droppo"] [data-testid="goerli-network-item"]`,
-  sepoliaNetworkItem: `[data-testid="network-droppo"] [data-testid="sepolia-network-item"]`,
+  sepoliaNetworkItem: `.multichain-network-list-menu-content-wrapper__dialog [data-testid="Sepolia"]`,
   localhostNetworkItem: `[data-testid="network-droppo"] [data-testid="Localhost 8545-network-item"]`,
   networkButton: number =>
     `[data-testid="network-droppo"] .dropdown-menu-item:nth-child(${
@@ -74,8 +74,8 @@ const accountMenu = {
 
 const optionsMenu = {
   button: '[data-testid=account-options-menu-button]',
-  accountDetailsButton: '[data-testid="account-options-menu__account-details"]',
-  connectedSitesButton: '[data-testid="account-options-menu__connected-sites"]',
+  accountDetailsButton: '[data-testid="account-list-menu-details"]',
+  connectedSitesButton: '[data-testid="global-menu-connected-sites"]',
 };
 
 const connectedSitesSelector = '.connected-sites';
@@ -87,10 +87,11 @@ const connectedSites = {
   closeButton: `${connectedSitesSelector} [data-testid="popover-close"]`,
 };
 
-const accountModalSelector = '.account-modal';
+const accountModalSelector = '.mm-modal-content__dialog';
 const accountModal = {
-  walletAddressInput: `${accountModalSelector} .qr-code__address`,
-  closeButton: '.account-modal__close',
+  walletAddressInput: `${accountModalSelector} [data-testid="address-copy-button-text"]`,
+  closeButton: `${accountModalSelector}  .mm-button-icon[aria-label="Close"]`,
+  primaryButton: `${accountModalSelector} button.mm-button-primary`,
 };
 
 const renameAccount = {

--- a/pages/metamask/notification-page.js
+++ b/pages/metamask/notification-page.js
@@ -2,12 +2,12 @@ const notificationPage = '.notification';
 const notificationAppContent = `${notificationPage} #app-content .app`;
 const loadingLogo = `${notificationPage} #loading__logo`;
 const loadingSpinner = `${notificationPage} #loading__spinner`;
-const nextButton = `${notificationPage} .permissions-connect-choose-account__bottom-buttons .btn-primary`;
+const nextButton = `${notificationPage} [data-testid="page-container-footer-next"]`;
 const cancelButton = `${notificationPage} .permissions-connect-choose-account__bottom-buttons .btn-secondary`;
 const customSpendingLimitInput = `${notificationPage} [data-testid="custom-spending-cap-input"]`;
 const allowToSpendButton = `${notificationPage} [data-testid="page-container-footer-next"]`;
 const rejectToSpendButton = `${notificationPage} [data-testid="page-container-footer-cancel"]`;
-const selectAllCheckbox = `${notificationPage} .choose-account-list__header-check-box`;
+const selectAllCheckbox = `${notificationPage} [data-testid="choose-account-list-operate-all-check-box"]`;
 const approveWarningToSpendButton = `${notificationPage} .set-approval-for-all-warning__footer__approve-button`;
 const rejectWarningToSpendButton = `${notificationPage} .btn-secondary.set-approval-for-all-warning__footer__cancel-button`;
 
@@ -50,10 +50,10 @@ module.exports.permissionsPageElements = {
   connectButton,
 };
 
-const popupContainer = '.popover-container';
-const popupCloseButton = `${popupContainer} .popover-header__button`;
-const popupCopyRecipientPublicAddressButton = `${popupContainer} .nickname-popover__public-address button`;
-const recipientPublicAddress = `${popupContainer} .nickname-popover__public-address__constant`;
+const popupContainer = '.mm-modal';
+const popupCloseButton = `${popupContainer} [aria-label="Close"]`;
+const popupCopyRecipientPublicAddressButton = `${popupContainer} [aria-label="Copy address to clipboard"]`;
+const recipientPublicAddress = `${popupContainer} .mm-text-field--disabled input`;
 module.exports.recipientPopupElements = {
   popupContainer,
   popupCloseButton,

--- a/pages/metamask/settings-page.js
+++ b/pages/metamask/settings-page.js
@@ -11,22 +11,18 @@ module.exports.settingsPageElements = {
 
 const resetAccountButton =
   '[data-testid="advanced-setting-reset-account"] button';
-const advancedGasControlToggleOn =
-  '[data-testid="advanced-setting-advanced-gas-inline"] .toggle-button--on';
-const advancedGasControlToggleOff =
-  '[data-testid="advanced-setting-advanced-gas-inline"] .toggle-button--off';
 const showHexDataToggleOn =
   '[data-testid="advanced-setting-hex-data"] .toggle-button--on';
 const showHexDataToggleOff =
   '[data-testid="advanced-setting-hex-data"] .toggle-button--off';
 const showTestnetConversionOn =
-  '[data-testid="advanced-setting-show-testnet-conversion"]:nth-child(6) .toggle-button--on';
+  'div.settings-page__content__modules > div.settings-page__body > div:nth-child(5) .toggle-button--on';
 const showTestnetConversionOff =
-  '[data-testid="advanced-setting-show-testnet-conversion"]:nth-child(6) .toggle-button--off';
+  'div.settings-page__content__modules > div.settings-page__body > div:nth-child(5) .toggle-button--off';
 const showTestnetNetworksOn =
-  '[data-testid="advanced-setting-show-testnet-conversion"]:nth-child(7) .toggle-button--on';
+  'div.settings-page__content__modules > div.settings-page__body > div:nth-child(6) .toggle-button--on';
 const showTestnetNetworksOff =
-  '[data-testid="advanced-setting-show-testnet-conversion"]:nth-child(7) .toggle-button--off';
+  'div.settings-page__content__modules > div.settings-page__body > div:nth-child(6) .toggle-button--off';
 const customNonceToggleOn =
   '[data-testid="advanced-setting-custom-nonce"] .toggle-button--on';
 const customNonceToggleOff =
@@ -41,8 +37,6 @@ const ethSignRequestsToggleOff =
   '[data-testid="advanced-setting-toggle-ethsign"] .toggle-button--off';
 module.exports.advancedPageElements = {
   resetAccountButton,
-  advancedGasControlToggleOn,
-  advancedGasControlToggleOff,
   showHexDataToggleOn,
   showHexDataToggleOff,
   showTestnetConversionOn,
@@ -80,7 +74,7 @@ const addNetworkForm = '.networks-tab__add-network-form-body';
 const networkNameInput = `${addNetworkForm} .form-field:nth-child(1) input`;
 const rpcUrlInput = `${addNetworkForm} .form-field:nth-child(2) input`;
 const chainIdInput = `${addNetworkForm} .form-field:nth-child(3) input`;
-const symbolInput = `${addNetworkForm} .form-field:nth-child(4) input`;
+const symbolInput = `${addNetworkForm} [data-testid="network-form-ticker"] input`;
 const blockExplorerInput = `${addNetworkForm} .form-field:nth-child(5) input`;
 const saveButton = '.networks-tab__add-network-form-footer .btn-primary';
 module.exports.addNetworkPageElements = {


### PR DESCRIPTION
## Motivation and context

Current version of synpress was missing some commands to setup latest metamask v11.15.5. 
In this PR we have fixed First time flow, Main page, Notification and setting page selectors.

## Does it fix any issue?

#(issue)

## Other useful info

N/A

## Quality checklist

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
