### PR TITLE
chore(readme): remove empty ul elements & spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,10 @@ Curious and want to learn more? 🤓
 
 [Read this Twitter thread 🧵](https://twitter.com/0xDuckception/status/1712961542176596054) and do not forget to check out the attached document there!
 
-# Table of content
+# Table of contents
 
-- [](#)
-- [](#-1)
-- [Table of content](#table-of-content)
+- [Table of contents](#table-of-content)
+  
   - [🧑‍🤝‍🧑 Community](#-community)
   - [🖥️ Install](#️-install)
   - [⚙️ Supported frameworks](#️-supported-frameworks)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Curious and want to learn more? 🤓
 # Table of contents
 
 - [Table of contents](#table-of-content)
-  
   - [🧑‍🤝‍🧑 Community](#-community)
   - [🖥️ Install](#️-install)
   - [⚙️ Supported frameworks](#️-supported-frameworks)


### PR DESCRIPTION
This PR aims to remove extra elements in the unordered list that precede the `Table of Contents` list. Additionally, I've changed `Table of Content` to `Table of Contents`

--
Love the work y'all do!