### PR TITLE
🐛 fix: Add confirm signature race condition handler

### DIFF
--- a/wallets/metamask/src/pages/NotificationPage/page.ts
+++ b/wallets/metamask/src/pages/NotificationPage/page.ts
@@ -33,20 +33,20 @@ export class NotificationPage {
   private async beforeMessageSignature(extensionId: string) {
     const notificationPage = await getNotificationPageAndWaitForLoad(this.page.context(), extensionId)
     const scrollDownButton = notificationPage.locator(Selectors.SignaturePage.structuredMessage.scrollDownButton)
-  
-    let isScrollButtonVisible = false;
-  
-    const scrollButtonPromise = scrollDownButton.waitFor({ state: 'visible' }).then(async () => {
-      isScrollButtonVisible = true;
-      await scrollDownButton.click();
-      return true;
-    }).catch(() => false);
-  
-    await Promise.race([
-      scrollButtonPromise,
-      notificationPage.waitForLoadState('load').then(() => false)
-    ]);
-  
+
+    let isScrollButtonVisible = false
+
+    const scrollButtonPromise = scrollDownButton
+      .waitFor({ state: 'visible' })
+      .then(async () => {
+        isScrollButtonVisible = true
+        await scrollDownButton.click()
+        return true
+      })
+      .catch(() => false)
+
+    await Promise.race([scrollButtonPromise, notificationPage.waitForLoadState('load').then(() => false)])
+
     return {
       notificationPage,
       isScrollButtonVisible

--- a/wallets/metamask/src/pages/NotificationPage/page.ts
+++ b/wallets/metamask/src/pages/NotificationPage/page.ts
@@ -1,6 +1,5 @@
 import type { Page } from '@playwright/test'
 import { getNotificationPageAndWaitForLoad } from '../../utils/getNotificationPageAndWaitForLoad'
-import { waitFor } from '../../utils/waitFor'
 import {
   type GasSetting,
   approvePermission,
@@ -31,18 +30,23 @@ export class NotificationPage {
     await connectToDapp(notificationPage, accounts)
   }
 
-  // TODO: Revisit this logic in the future to see if we can increase the performance by utilizing `Promise.race`.
   private async beforeMessageSignature(extensionId: string) {
     const notificationPage = await getNotificationPageAndWaitForLoad(this.page.context(), extensionId)
-
-    // TODO: Make this configurable.
-    // Most of the time, this function will be used to sign structured messages, so we check for the scroll button first.
-    const isScrollButtonVisible = await waitFor(
-      () => notificationPage.locator(Selectors.SignaturePage.structuredMessage.scrollDownButton).isVisible(),
-      1_500,
-      false
-    )
-
+    const scrollDownButton = notificationPage.locator(Selectors.SignaturePage.structuredMessage.scrollDownButton)
+  
+    let isScrollButtonVisible = false;
+  
+    const scrollButtonPromise = scrollDownButton.waitFor({ state: 'visible' }).then(async () => {
+      isScrollButtonVisible = true;
+      await scrollDownButton.click();
+      return true;
+    }).catch(() => false);
+  
+    await Promise.race([
+      scrollButtonPromise,
+      notificationPage.waitForLoadState('load').then(() => false)
+    ]);
+  
     return {
       notificationPage,
       isScrollButtonVisible


### PR DESCRIPTION
## Motivation and context

This PR introduces an enhancement to the `beforeMessageSignature` method in the `Page` class. The method now efficiently handles two scenarios: when a scroll button is present on the page and when it's not. This is achieved by using `Promise.race()` to wait for either the scroll button to become visible and clicked, or for the page to finish loading.

The motivation behind this change is to improve the performance and reliability of the method. Previously, the method could potentially be delayed if the scroll button was not present. With this enhancement, the method will proceed as soon as the relevant condition is met, without any manual delays.

## Does it fix any issue?

SYN-83

## Other useful info

This enhancement should improve the performance of any operations that involve the `beforeMessageSignature` method.

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
