### PR TITLE
✨ feat: wait for loading indicators inside notification page

### DIFF
--- a/wallets/metamask/src/pages/NotificationPage/page.ts
+++ b/wallets/metamask/src/pages/NotificationPage/page.ts
@@ -1,6 +1,5 @@
 import type { Page } from '@playwright/test'
 import { getNotificationPageAndWaitForLoad } from '../../utils/getNotificationPageAndWaitForLoad'
-import { waitFor } from '../../utils/waitFor'
 import {
   type GasSetting,
   approvePermission,
@@ -31,17 +30,17 @@ export class NotificationPage {
     await connectToDapp(notificationPage, accounts)
   }
 
-  // TODO: Revisit this logic in the future to see if we can increase the performance by utilizing `Promise.race`.
   private async beforeMessageSignature(extensionId: string) {
     const notificationPage = await getNotificationPageAndWaitForLoad(this.page.context(), extensionId)
 
-    // TODO: Make this configurable.
-    // Most of the time, this function will be used to sign structured messages, so we check for the scroll button first.
-    const isScrollButtonVisible = await waitFor(
-      () => notificationPage.locator(Selectors.SignaturePage.structuredMessage.scrollDownButton).isVisible(),
-      1_500,
-      false
-    )
+    const scrollButton = notificationPage.locator(Selectors.SignaturePage.structuredMessage.scrollDownButton)
+    const isScrollButtonPresent = (await scrollButton.count()) > 0
+
+    let isScrollButtonVisible = false
+    if (isScrollButtonPresent) {
+      await scrollButton.waitFor({ state: 'visible' })
+      isScrollButtonVisible = true
+    }
 
     return {
       notificationPage,

--- a/wallets/metamask/src/utils/getNotificationPageAndWaitForLoad.ts
+++ b/wallets/metamask/src/utils/getNotificationPageAndWaitForLoad.ts
@@ -40,7 +40,6 @@ export async function getNotificationPageAndWaitForLoad(context: BrowserContext,
   const timeout = 5000
   for (const selector of loadingIndicators) {
     try {
-      console.log(`Loading indicator '${selector}' found, waiting for it to disappear`)
       await notificationPage.waitForSelector(selector, { state: 'hidden', timeout })
     } catch (error) {
       if (error instanceof errors.TimeoutError) {

--- a/wallets/metamask/src/utils/getNotificationPageAndWaitForLoad.ts
+++ b/wallets/metamask/src/utils/getNotificationPageAndWaitForLoad.ts
@@ -1,4 +1,5 @@
 import type { BrowserContext, Page } from '@playwright/test'
+import { errors } from '@playwright/test'
 
 export async function getNotificationPageAndWaitForLoad(context: BrowserContext, extensionId: string) {
   const notificationPageUrl = `chrome-extension://${extensionId}/notification.html`
@@ -20,7 +21,36 @@ export async function getNotificationPageAndWaitForLoad(context: BrowserContext,
     height: 592
   })
 
-  await notificationPage.waitForLoadState('load')
+  await notificationPage.waitForLoadState('domcontentloaded')
+
+  const loadingIndicators = [
+    '.loading-logo',
+    '.loading-spinner',
+    '.loading-overlay',
+    '.loading-overlay__spinner',
+    '.loading-span',
+    '.loading-indicator',
+    '#loading__logo',
+    '#loading__spinner',
+    '.mm-button-base__icon-loading',
+    '.loading-swaps-quotes',
+    '.loading-heartbeat'
+  ]
+
+  const timeout = 5000
+  for (const selector of loadingIndicators) {
+    try {
+      console.log(`Loading indicator '${selector}' found, waiting for it to disappear`)
+      await notificationPage.waitForSelector(selector, { state: 'hidden', timeout })
+    } catch (error) {
+      if (error instanceof errors.TimeoutError) {
+        console.log(`Loading indicator '${selector}' not found - continuing.`)
+      } else {
+        console.log(`Error while waiting for loading indicator '${selector}' to disappear`)
+        throw error
+      }
+    }
+  }
 
   return notificationPage
 }


### PR DESCRIPTION
- wait for loading indicators inside notification page
- get rid of delay from `isScrollButtonPresent`