### PR TITLE
✨ chore: Commands refactor with a few Metamask heleprs

### DIFF
--- a/wallets/metamask/src/cypress/MetaMask.ts
+++ b/wallets/metamask/src/cypress/MetaMask.ts
@@ -1,11 +1,258 @@
-import { lockPage } from '../selectors'
-import { MetaMaskAbstract } from '../type/MetaMaskAbstract'
+import { type BrowserContext, type Page, expect } from '@playwright/test'
+import { type CreateAnvilOptions, type Pool, createPool } from '@viem/anvil'
+import { MetaMask as MetaMaskPlaywright } from '../playwright/MetaMask'
+import { waitFor } from '../playwright/utils/waitFor'
+import HomePageSelectors from '../selectors/pages/HomePage'
+import Selectors from '../selectors/pages/HomePage'
+import type { Network } from '../type/Network'
+import getPlaywrightMetamask from './getPlaywrightMetamask'
 
-// @ts-ignore
-// TODO: To be implemented
-export class MetaMask extends MetaMaskAbstract {
-  unlock() {
-    cy.get(lockPage.passwordInput).type(this.password)
-    cy.get(lockPage.submitButton).click()
+let pool: Pool
+
+export default class MetaMask {
+  readonly metamaskPlaywright: MetaMaskPlaywright
+  readonly metamaskExtensionPage: Page
+
+  constructor(context: BrowserContext, metamaskExtensionPage: Page, metamaskExtensionId: string) {
+    this.metamaskPlaywright = getPlaywrightMetamask(context, metamaskExtensionPage, metamaskExtensionId)
+    this.metamaskExtensionPage = metamaskExtensionPage
+  }
+
+  async getAccount() {
+    return await this.metamaskExtensionPage
+      .locator(this.metamaskPlaywright.homePage.selectors.accountMenu.accountButton)
+      .innerText()
+  }
+
+  async getNetwork() {
+    return await this.metamaskExtensionPage
+      .locator(this.metamaskPlaywright.homePage.selectors.currentNetwork)
+      .innerText()
+  }
+
+  async connectToDapp(accounts?: string[]) {
+    return this.metamaskPlaywright
+      .connectToDapp(accounts)
+      .then(() => true)
+      .catch(() => false)
+  }
+
+  async addNewAccount(accountName: string) {
+    await this.metamaskPlaywright.addNewAccount(accountName)
+
+    await expect(
+      this.metamaskExtensionPage.locator(this.metamaskPlaywright.homePage.selectors.accountMenu.accountButton)
+    ).toHaveText(accountName)
+
+    return true
+  }
+
+  async switchAccount(accountName: string) {
+    await this.metamaskPlaywright.switchAccount(accountName)
+
+    await expect(
+      this.metamaskExtensionPage.locator(this.metamaskPlaywright.homePage.selectors.accountMenu.accountButton)
+    ).toHaveText(accountName)
+
+    return true
+  }
+
+  async renameAccount({
+    currentAccountName,
+    newAccountName
+  }: {
+    currentAccountName: string
+    newAccountName: string
+  }) {
+    await this.metamaskPlaywright.renameAccount(currentAccountName, newAccountName)
+
+    await this.metamaskExtensionPage.locator(HomePageSelectors.threeDotsMenu.accountDetailsCloseButton).click()
+
+    await expect(
+      this.metamaskExtensionPage.locator(this.metamaskPlaywright.homePage.selectors.accountMenu.accountButton)
+    ).toHaveText(newAccountName)
+
+    return true
+  }
+
+  async switchNetwork({
+    networkName,
+    isTestnet
+  }: {
+    networkName: string
+    isTestnet?: boolean
+  }) {
+    return await this.metamaskPlaywright
+      .switchNetwork(networkName, isTestnet)
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async createAnvilNode(options?: CreateAnvilOptions) {
+    pool = createPool()
+
+    const nodeId = Array.from(pool.instances()).length
+    const anvil = await pool.start(nodeId, options)
+
+    const rpcUrl = `http://${anvil.host}:${anvil.port}`
+
+    const DEFAULT_ANVIL_CHAIN_ID = 31337
+    const chainId = options?.chainId ?? DEFAULT_ANVIL_CHAIN_ID
+
+    return { anvil, rpcUrl, chainId }
+  }
+
+  async emptyAnvilNode() {
+    await pool.empty()
+    return true
+  }
+
+  async connectToAnvil({
+    rpcUrl,
+    chainId
+  }: {
+    rpcUrl: string
+    chainId: number
+  }) {
+    try {
+      await this.metamaskPlaywright.addNetwork({
+        name: 'Anvil',
+        rpcUrl,
+        chainId,
+        symbol: 'ETH',
+        blockExplorerUrl: 'https://etherscan.io/'
+      })
+
+      await this.metamaskPlaywright.switchNetwork('Anvil')
+      return true
+    } catch (e) {
+      console.error('Error connecting to Anvil network', e)
+      return false
+    }
+  }
+
+  async addNetwork(network: Network) {
+    await this.metamaskPlaywright.addNetwork(network)
+
+    await waitFor(
+      () => this.metamaskExtensionPage.locator(HomePageSelectors.networkAddedPopover.switchToNetworkButton).isVisible(),
+      3_000,
+      false
+    )
+
+    await this.metamaskExtensionPage.locator(HomePageSelectors.networkAddedPopover.switchToNetworkButton).click()
+
+    return true
+  }
+
+  // Token
+
+  async deployToken() {
+    await this.metamaskPlaywright.confirmTransaction()
+
+    return true
+  }
+
+  async addNewToken() {
+    await this.metamaskPlaywright.addNewToken()
+
+    await expect(this.metamaskExtensionPage.locator(Selectors.portfolio.singleToken).nth(1)).toContainText('TST')
+
+    return true
+  }
+
+  async approveNewNetwork() {
+    await this.metamaskPlaywright.approveNewNetwork()
+
+    return true
+  }
+
+  async approveSwitchNetwork() {
+    await this.metamaskPlaywright.approveSwitchNetwork()
+
+    return true
+  }
+
+  // Others
+
+  async providePublicEncryptionKey() {
+    return await this.metamaskPlaywright
+      .providePublicEncryptionKey()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async decrypt() {
+    return await this.metamaskPlaywright
+      .decrypt()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async confirmSignature() {
+    return await this.metamaskPlaywright
+      .confirmSignature()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async confirmTransaction() {
+    return await this.metamaskPlaywright
+      .confirmTransaction()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async confirmTransactionAndWaitForMining() {
+    return this.metamaskPlaywright
+      .confirmTransactionAndWaitForMining()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async openTransactionDetails(txIndex: number) {
+    return this.metamaskPlaywright
+      .openTransactionDetails(txIndex)
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
+  }
+
+  async closeTransactionDetails() {
+    return this.metamaskPlaywright
+      .closeTransactionDetails()
+      .then(() => {
+        return true
+      })
+      .catch(() => {
+        return false
+      })
   }
 }

--- a/wallets/metamask/src/cypress/MetaMask.ts
+++ b/wallets/metamask/src/cypress/MetaMask.ts
@@ -77,7 +77,7 @@ export default class MetaMask {
 
   async switchNetwork({
     networkName,
-    isTestnet
+    isTestnet = false
   }: {
     networkName: string
     isTestnet?: boolean

--- a/wallets/metamask/src/cypress/configureSynpress.ts
+++ b/wallets/metamask/src/cypress/configureSynpress.ts
@@ -80,7 +80,7 @@ export default function configureSynpress(on: Cypress.PluginEvents, config: Cypr
     getNetwork: () => metamask?.getNetwork(),
     switchNetwork: ({
       networkName,
-      isTestnet
+      isTestnet = false
     }: {
       networkName: string
       isTestnet?: boolean

--- a/wallets/metamask/src/cypress/support/synpressCommands.ts
+++ b/wallets/metamask/src/cypress/support/synpressCommands.ts
@@ -44,6 +44,8 @@ declare global {
       confirmSignature(): Chainable<void>
       confirmTransaction(): Chainable<void>
       confirmTransactionAndWaitForMining(): Chainable<void>
+      openTransactionDetails(txIndex: number): Chainable<void>
+      closeTransactionDetails(): Chainable<void>
     }
   }
 }
@@ -137,5 +139,11 @@ export default function synpressCommands() {
   })
   Cypress.Commands.add('confirmTransactionAndWaitForMining', () => {
     return cy.task('confirmTransactionAndWaitForMining')
+  })
+  Cypress.Commands.add('openTransactionDetails', (txIndex = 0) => {
+    return cy.task('openTransactionDetails', txIndex)
+  })
+  Cypress.Commands.add('closeTransactionDetails', () => {
+    return cy.task('closeTransactionDetails')
   })
 }

--- a/wallets/metamask/test/cypress/approveNewNetwork.cy.ts
+++ b/wallets/metamask/test/cypress/approveNewNetwork.cy.ts
@@ -14,3 +14,7 @@ it('should add a new network', () => {
     })
   })
 })
+
+after(() => {
+  cy.switchNetwork('Ethereum Mainnet')
+})


### PR DESCRIPTION
## Motivation and context

1. Added a few Metamask helpers to the Cypress commands:
- metamask.confirmTransactionAndWaitForMining()
- metamask.openTransactionDetails(0)
- metamask.closeTransactionDetails()

2. Refactored all the Cypress commands to make it clean.

## Does it fix any issue?

https://linear.app/synpress/issue/SYN-133/make-it-possible-to-close-transaction-details

## Quality checklist

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough e2e tests.

**⚠️👆 Delete any section you see irrelevant before submitting the pull request 👆⚠️**
