### PR TITLE
Update notification-page.js

### DIFF
--- a/pages/metamask/notification-page.js
+++ b/pages/metamask/notification-page.js
@@ -26,7 +26,7 @@ module.exports.notificationPageElements = {
   rejectWarningToSpendButton,
 };
 
-const confirmSignatureRequestButton = `${notificationPage} [data-testid="page-container-footer-next"]`;
+const confirmSignatureRequestButton = `${notificationPage} [data-testid="request-signature__sign"]`;
 const rejectSignatureRequestButton = `${notificationPage} [data-testid="page-container-footer-cancel"]`;
 const signatureRequestScrollDownButton = `${notificationPage} [data-testid="signature-request-scroll-button"]`;
 module.exports.signaturePageElements = {


### PR DESCRIPTION
confirmSignatureRequestButton css locator has been changed

While using the Metamask version 10.25.0 I am not able to automate the SignIn button in the signature request page. 

This is because the actual css locator is different  than the css locator mention in the Synpress library. I have attahced the detailed screenshots. I am assuming that I will get some solution from your team so I can use the metamask efficiently. Thank you!

![GitHubUpload](https://github.com/user-attachments/assets/759beec3-9ce9-4672-8e1f-f24e59d21354)
![Signature request](https://github.com/user-attachments/assets/b108aee1-a472-4339-b0f1-8ba51f1f1217)
